### PR TITLE
Updated API to allow more flexible styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,27 +30,31 @@ The addon provides 1 Glimmer component and 2 helpers:
 
 #### `<ContainerQuery>`
 
-The component accepts these arguments:
+The component uses `...attributes` so that you can pass `class` or `local-class` _for styling_.<sup>1</sup>
+
+It also accepts these arguments:
 
 | Name | Required | Description | Type |
 |--|:--:|--|--|
-| @breakpoints | Yes<sup>1</sup> | Container query definitions | POJO |
-| @classPrefix | No | Prefix for CSS selectors | string |
+| @breakpoints | Yes<sup>2</sup> | Container query definitions | POJO |
+| @dataAttributePrefix | No | Prefix for data attributes | string |
 | @debounce | No | Debounce time (ms) for resize | number ≥ 0 |
 
-It returns a few values that you can consume:<sup>2</sup>
+The component returns a few values that you can consume:<sup>3</sup>
 
 | Name | Yielded | Description |
 |--|:--:|--|
 | breakpoints | Yes | container query results |
 | height | Yes | container height |
 | width | Yes | container width |
-| container-query--_{breakpointName}_ | No | CSS selector(s) |
+| data-container-query-_{breakpointName}_ | No | Data attributes for CSS selector |
 | data-test-container-query | No | test selector |
 
-<sup>1. The component renders without error when `@breakpoints` isn't provided. In practice, you will always want to set `@breakpoints`.</sup>
+<sup>1. Do refrain from overusing splattributes (e.g. pass a `{{did-insert}}` modifier to fetch data), since the component's API may change and cause unexpected results. Practice separation of concerns when possible. For example, data fetching can be handled by another element or [`@use` decorator](https://github.com/emberjs/rfcs/blob/use-and-resources/text/0567-use-and-resources.md).</sup>
 
-<sup>2. In practice, you will likely only use `breakpoints` (maybe CSS selectors).</sup>
+<sup>2. The component renders without error when `@breakpoints` isn't provided. In practice, you will always want to set `@breakpoints`.</sup>
+
+<sup>3. In practice, you will likely only use `breakpoints` and data attributes for CSS selector.</sup>
 
 #### `{{cq-height}}`,  `{{cq-width}}`
 

--- a/addon/components/container-query.hbs
+++ b/addon/components/container-query.hbs
@@ -1,8 +1,9 @@
 <div
-  class="container-query {{this.classSelectors}}"
+  class="container-query"
   data-test-container-query
   {{did-insert this.queryContainer}}
   {{did-resize this.queryContainer debounce=this.debounce}}
+  ...attributes
 >
   {{yield (hash
     breakpoints=this.queryResults

--- a/addon/components/container-query.js
+++ b/addon/components/container-query.js
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 
 export default class ContainerQueryComponent extends Component {
   @tracked queryResults = {};
-  @tracked classSelectors = '';
   @tracked height;
   @tracked width;
 
@@ -12,8 +11,8 @@ export default class ContainerQueryComponent extends Component {
     return this.args.breakpoints ?? {};
   }
 
-  get classPrefix() {
-    return this.args.classPrefix ?? 'container-query';
+  get dataAttributePrefix() {
+    return this.args.dataAttributePrefix ?? 'container-query';
   }
 
   get debounce() {
@@ -25,7 +24,7 @@ export default class ContainerQueryComponent extends Component {
     this.width = element.clientWidth;
 
     this.evaluateQueries();
-    this.setClassSelectors();
+    this.setDataAttributes(element);
   }
 
   evaluateQueries() {
@@ -47,16 +46,19 @@ export default class ContainerQueryComponent extends Component {
     this.queryResults = queryResults;
   }
 
-  setClassSelectors() {
-    const classPrefix = this.classPrefix;
-    const classSelectors = [];
+  setDataAttributes(element) {
+    const prefix = this.dataAttributePrefix;
 
     for (const [name, meetsBreakpoint] of Object.entries(this.queryResults)) {
+      const attributeName = `data-${prefix}-${name}`;
+
       if (meetsBreakpoint) {
-        classSelectors.push(`${classPrefix}--${name}`);
+        element.setAttribute(attributeName, '');
+
+      } else {
+        element.removeAttribute(attributeName);
+
       }
     }
-
-    this.classSelectors = classSelectors.join(' ');
   }
 }

--- a/tests/integration/components/container-query-test.js
+++ b/tests/integration/components/container-query-test.js
@@ -227,8 +227,8 @@ module('@desktop Integration | Component | container-query', function(hooks) {
   });
 
 
-  module('When @classPrefix is undefined', function() {
-    test('The component updates this.classSelectors when it is resized', async function(assert) {
+  module('When @dataAttributePrefix is undefined', function() {
+    test('The component updates data attributes when it is resized', async function(assert) {
       await render(hbs`
         <div
           data-test-parent-element
@@ -255,44 +255,44 @@ module('@desktop Integration | Component | container-query', function(hooks) {
       `);
 
       assert.dom('[data-test-container-query]')
-        .hasClass('container-query--small')
-        .doesNotHaveClass('container-query--medium')
-        .doesNotHaveClass('container-query--large')
-        .doesNotHaveClass('container-query--short')
-        .hasClass('container-query--tall');
+        .hasAttribute('data-container-query-small')
+        .doesNotHaveAttribute('data-container-query-medium')
+        .doesNotHaveAttribute('data-container-query-large')
+        .doesNotHaveAttribute('data-container-query-short')
+        .hasAttribute('data-container-query-tall');
 
       await resizeWindow(500, 300);
 
       assert.dom('[data-test-container-query]')
-        .doesNotHaveClass('container-query--small')
-        .hasClass('container-query--medium')
-        .doesNotHaveClass('container-query--large')
-        .hasClass('container-query--short')
-        .doesNotHaveClass('container-query--tall');
+        .doesNotHaveAttribute('data-container-query-small')
+        .hasAttribute('data-container-query-medium')
+        .doesNotHaveAttribute('data-container-query-large')
+        .hasAttribute('data-container-query-short')
+        .doesNotHaveAttribute('data-container-query-tall');
 
       await resizeWindow(800, 400);
 
       assert.dom('[data-test-container-query]')
-        .doesNotHaveClass('container-query--small')
-        .doesNotHaveClass('container-query--medium')
-        .hasClass('container-query--large')
-        .hasClass('container-query--short')
-        .doesNotHaveClass('container-query--tall');
+        .doesNotHaveAttribute('data-container-query-small')
+        .doesNotHaveAttribute('data-container-query-medium')
+        .hasAttribute('data-container-query-large')
+        .hasAttribute('data-container-query-short')
+        .doesNotHaveAttribute('data-container-query-tall');
 
       await resizeWindow(1000, 600);
 
       assert.dom('[data-test-container-query]')
-        .doesNotHaveClass('container-query--small')
-        .doesNotHaveClass('container-query--medium')
-        .doesNotHaveClass('container-query--large')
-        .doesNotHaveClass('container-query--short')
-        .hasClass('container-query--tall');
+        .doesNotHaveAttribute('data-container-query-small')
+        .doesNotHaveAttribute('data-container-query-medium')
+        .doesNotHaveAttribute('data-container-query-large')
+        .doesNotHaveAttribute('data-container-query-short')
+        .hasAttribute('data-container-query-tall');
     });
   });
 
 
-  module('When @classPrefix is passed', function() {
-    test('The component updates this.classSelectors when it is resized', async function(assert) {
+  module('When @dataAttributePrefix is passed', function() {
+    test('The component updates data attributes when it is resized', async function(assert) {
       await render(hbs`
         <div
           data-test-parent-element
@@ -306,7 +306,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
               short=(cq-height max=500)
               tall=(cq-height min=500)
             }}
-            @classPrefix="my-app-initials"
+            @dataAttributePrefix="cq"
             as |CQ|
           >
             <p data-test-physical-size>{{CQ.width}} x {{CQ.height}}</p>
@@ -320,38 +320,80 @@ module('@desktop Integration | Component | container-query', function(hooks) {
       `);
 
       assert.dom('[data-test-container-query]')
-        .hasClass('my-app-initials--small')
-        .doesNotHaveClass('my-app-initials--medium')
-        .doesNotHaveClass('my-app-initials--large')
-        .doesNotHaveClass('my-app-initials--short')
-        .hasClass('my-app-initials--tall');
+        .hasAttribute('data-cq-small')
+        .doesNotHaveAttribute('data-cq-medium')
+        .doesNotHaveAttribute('data-cq-large')
+        .doesNotHaveAttribute('data-cq-short')
+        .hasAttribute('data-cq-tall');
 
       await resizeWindow(500, 300);
 
       assert.dom('[data-test-container-query]')
-        .doesNotHaveClass('my-app-initials--small')
-        .hasClass('my-app-initials--medium')
-        .doesNotHaveClass('my-app-initials--large')
-        .hasClass('my-app-initials--short')
-        .doesNotHaveClass('my-app-initials--tall');
+        .doesNotHaveAttribute('data-cq-small')
+        .hasAttribute('data-cq-medium')
+        .doesNotHaveAttribute('data-cq-large')
+        .hasAttribute('data-cq-short')
+        .doesNotHaveAttribute('data-cq-tall');
 
       await resizeWindow(800, 400);
 
       assert.dom('[data-test-container-query]')
-        .doesNotHaveClass('my-app-initials--small')
-        .doesNotHaveClass('my-app-initials--medium')
-        .hasClass('my-app-initials--large')
-        .hasClass('my-app-initials--short')
-        .doesNotHaveClass('my-app-initials--tall');
+        .doesNotHaveAttribute('data-cq-small')
+        .doesNotHaveAttribute('data-cq-medium')
+        .hasAttribute('data-cq-large')
+        .hasAttribute('data-cq-short')
+        .doesNotHaveAttribute('data-cq-tall');
 
       await resizeWindow(1000, 600);
 
       assert.dom('[data-test-container-query]')
-        .doesNotHaveClass('my-app-initials--small')
-        .doesNotHaveClass('my-app-initials--medium')
-        .doesNotHaveClass('my-app-initials--large')
-        .doesNotHaveClass('my-app-initials--short')
-        .hasClass('my-app-initials--tall');
+        .doesNotHaveAttribute('data-cq-small')
+        .doesNotHaveAttribute('data-cq-medium')
+        .doesNotHaveAttribute('data-cq-large')
+        .doesNotHaveAttribute('data-cq-short')
+        .hasAttribute('data-cq-tall');
+    });
+  });
+
+
+  module('...attributes', function() {
+    test('The component accepts splattributes', async function(assert) {
+      assert.expect(3);
+
+      this.fetchData = () => {
+        assert.ok('{{did-insert}} modifier works. (But we should find a better way to separate concerns!)');
+      };
+
+      await render(hbs`
+        <div style="width: 500px; height: 800px;">
+          <ContainerQuery
+            @breakpoints={{hash
+              small=(cq-width max=300)
+              medium=(cq-width min=300 max=600)
+              large=(cq-width min=600 max=900)
+              short=(cq-height max=500)
+              tall=(cq-height min=500)
+            }}
+
+            class="unique-class-name"
+            local-class="container"
+            {{did-insert this.fetchData}}
+
+            as |CQ|
+          >
+            <p data-test-physical-size>{{CQ.width}} x {{CQ.height}}</p>
+            <p data-test-breakpoint="small">{{CQ.breakpoints.small}}</p>
+            <p data-test-breakpoint="medium">{{CQ.breakpoints.medium}}</p>
+            <p data-test-breakpoint="large">{{CQ.breakpoints.large}}</p>
+            <p data-test-breakpoint="short">{{CQ.breakpoints.short}}</p>
+            <p data-test-breakpoint="tall">{{CQ.breakpoints.tall}}</p>
+          </ContainerQuery>
+        </div>
+      `);
+
+      assert.dom('[data-test-container-query]')
+        .hasClass('unique-class-name', 'Providing a custom CSS class works.')
+        .hasAttribute('local-class', 'container', 'ember-css-modules works.');
     });
   });
 });


### PR DESCRIPTION
## Description

While working on the next example for the demo app, I realized that the current API makes it impossible to use the `local-class` feature from `ember-css-modules`.

I used `...attributes` (splattributes) to allow users to pass `class` or `local-class` of their choice. I updated tests and README file to document how users should (and should not) use the new API.


## Credits

Thanks to running into the problem above, I finally understood why Chad had recommended the [`CSS Breakpoint Selectors` approach](https://github.com/chadian/ember-fill-up#responsive-component-strategies) with his `ember-fill-up`. 💡

I will document how to use the data attributes for styling in the upcoming example.