### PR TITLE
Renamed breakpoints to features

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It also accepts these arguments:
 
 | Name | Required | Description | Type |
 |--|:--:|--|--|
-| @breakpoints | Yes<sup>2</sup> | Container query definitions | POJO |
+| @features | Yes<sup>2</sup> | Container query definitions | POJO |
 | @dataAttributePrefix | No | Prefix for data attributes | string |
 | @debounce | No | Debounce time (ms) for resize | number ≥ 0 |
 
@@ -45,13 +45,13 @@ The component returns a few values that you can consume:
 
 | Name | Yielded | Description |
 |--|:--:|--|
-| breakpoints | Yes | Container query results |
-| data-container-query-_{breakpointName}_ | No | Data attributes for CSS selector |
+| features | Yes | Container query results |
+| data-container-query-_{featureName}_ | No | Data attributes for CSS selector |
 | data-test-container-query | No | Test selector |
 
 <sup>1. Do refrain from overusing splattributes (e.g. pass a `{{did-insert}}` modifier to fetch data), since the component's API may change and cause unexpected results. Practice separation of concerns when possible. For example, data fetching can be handled by another element or [`@use` decorator](https://github.com/emberjs/rfcs/blob/use-and-resources/text/0567-use-and-resources.md).</sup>
 
-<sup>2. The component renders without error when `@breakpoints` isn't provided. In practice, you will always want to set `@breakpoints`.</sup>
+<sup>2. The component renders without error when `@features` isn't provided. In practice, you will always want to set `@features`.</sup>
 
 
 #### `{{cq-aspect-ratio}}`, `{{cq-height}}`,  `{{cq-width}}`
@@ -60,8 +60,8 @@ All helpers accept these arguments:
 
 | Name | Required | Description | Type |
 |--|:--:|--|--|
-| min | Yes<sup>1,2</sup> | Lower bound for dimension | number ≥ 0 |
-| max | Yes<sup>1,2</sup> | Upper bound for dimension | number ≥ 0 |
+| min | Yes<sup>1,2</sup> | Lower bound for feature | number ≥ 0 |
+| max | Yes<sup>1,2</sup> | Upper bound for feature | number ≥ 0 |
 
 <sup>1. The helpers use default values of `min = 0` and `max = Infinity`, and assume the inequalities `min ≤ x < max`. In practice, you will always want to set `min` or `max` (or both).</sup>
 
@@ -79,14 +79,14 @@ When you pair `<ContainerQuery>` with some [CSS](https://github.com/salsify/embe
 {{!-- app/templates/album.hbs --}}
 
 <ContainerQuery
-  @breakpoints={{hash
+  @features={{hash
     large=(cq-width min=960)
     tall=(cq-height min=400)
   }}
   as |CQ|
 >
   {{#let
-    (and CQ.breakpoints.large CQ.breakpoints.tall)
+    (and CQ.features.large CQ.features.tall)
     as |showLyrics|
   }}
     <section local-class="container {{if showLyrics "with-lyrics"}}">
@@ -117,7 +117,7 @@ When you pair `<ContainerQuery>` with some [CSS](https://github.com/salsify/embe
 {{!-- app/components/tracks.hbs --}}
 
 <ContainerQuery
-  @breakpoints={{hash
+  @features={{hash
     small=(cq-width max=480)
     medium=(cq-width min=480 max=640)
     large=(cq-width min=640)
@@ -125,7 +125,7 @@ When you pair `<ContainerQuery>` with some [CSS](https://github.com/salsify/embe
   }}
   as |CQ|
 >
-  {{#if (and CQ.breakpoints.large CQ.breakpoints.tall)}}
+  {{#if (and CQ.features.large CQ.features.tall)}}
     <Tracks::Table
       @tracks={{@tracks}}
     />
@@ -133,8 +133,8 @@ When you pair `<ContainerQuery>` with some [CSS](https://github.com/salsify/embe
   {{else}}
     <Tracks::List
       @numColumns={{
-        if CQ.breakpoints.small 1
-        (if CQ.breakpoints.medium 2 3)
+        if CQ.features.small 1
+        (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
     />

--- a/addon/components/container-query.hbs
+++ b/addon/components/container-query.hbs
@@ -6,6 +6,6 @@
   ...attributes
 >
   {{yield (hash
-    breakpoints=this.queryResults
+    features=this.queryResults
   )}}
 </div>

--- a/addon/components/container-query.js
+++ b/addon/components/container-query.js
@@ -5,8 +5,8 @@ import { tracked } from '@glimmer/tracking';
 export default class ContainerQueryComponent extends Component {
   @tracked queryResults = {};
 
-  get breakpoints() {
-    return this.args.breakpoints ?? {};
+  get features() {
+    return this.args.features ?? {};
   }
 
   get dataAttributePrefix() {
@@ -18,18 +18,21 @@ export default class ContainerQueryComponent extends Component {
   }
 
   @action queryContainer(element) {
+    this.measureDimensions(element);
+    this.evaluateQueries();
+    this.setDataAttributes(element);
+  }
+
+  measureDimensions(element) {
     this.height = element.clientHeight;
     this.width = element.clientWidth;
     this.aspectRatio = this.width / this.height;
-
-    this.evaluateQueries();
-    this.setDataAttributes(element);
   }
 
   evaluateQueries() {
     const queryResults = {};
 
-    for (const [name, metadata] of Object.entries(this.breakpoints)) {
+    for (const [name, metadata] of Object.entries(this.features)) {
       const { dimension, min, max } = metadata;
       const value = this[dimension];
 
@@ -42,10 +45,10 @@ export default class ContainerQueryComponent extends Component {
   setDataAttributes(element) {
     const prefix = this.dataAttributePrefix;
 
-    for (const [name, meetsBreakpoint] of Object.entries(this.queryResults)) {
+    for (const [name, meetsFeature] of Object.entries(this.queryResults)) {
       const attributeName = `data-${prefix}-${name}`;
 
-      if (meetsBreakpoint) {
+      if (meetsFeature) {
         element.setAttribute(attributeName, '');
 
       } else {

--- a/tests/dummy/app/components/tracks/index.hbs
+++ b/tests/dummy/app/components/tracks/index.hbs
@@ -1,5 +1,5 @@
 <ContainerQuery
-  @breakpoints={{hash
+  @features={{hash
     small=(cq-width max=480)
     medium=(cq-width min=480 max=640)
     large=(cq-width min=640)
@@ -7,7 +7,7 @@
   }}
   as |CQ|
 >
-  {{#if (and CQ.breakpoints.large CQ.breakpoints.tall)}}
+  {{#if (and CQ.features.large CQ.features.tall)}}
     <Tracks::Table
       @tracks={{@tracks}}
     />
@@ -15,8 +15,8 @@
   {{else}}
     <Tracks::List
       @numColumns={{
-        if CQ.breakpoints.small 1
-        (if CQ.breakpoints.medium 2 3)
+        if CQ.features.small 1
+        (if CQ.features.medium 2 3)
       }}
       @tracks={{@tracks}}
     />

--- a/tests/dummy/app/templates/album.hbs
+++ b/tests/dummy/app/templates/album.hbs
@@ -1,11 +1,11 @@
 <ContainerQuery
-  @breakpoints={{hash
+  @features={{hash
     large=(cq-width min=960)
     tall=(cq-height min=400)
   }}
   as |CQ|
 >
-  {{#let (and CQ.breakpoints.large CQ.breakpoints.tall) as |showLyrics|}}
+  {{#let (and CQ.features.large CQ.features.tall) as |showLyrics|}}
     <section local-class="container {{if showLyrics "with-lyrics"}}">
       <header local-class="album-header">
         <h1>{{@model.name}}</h1>

--- a/tests/integration/components/container-query-test.js
+++ b/tests/integration/components/container-query-test.js
@@ -8,16 +8,16 @@ module('@desktop Integration | Component | container-query', function(hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function(assert) {
-    assert.areBreakpointsCorrect = (breakpoints = {}) => {
-      for (const [name, meetsBreakpoint] of Object.entries(breakpoints)) {
-        if (meetsBreakpoint) {
-          assert.dom(`[data-test-breakpoint="${name}"]`).hasText('true');
+    assert.areFeaturesCorrect = (features = {}) => {
+      for (const [name, meetsFeature] of Object.entries(features)) {
+        if (meetsFeature) {
+          assert.dom(`[data-test-feature="${name}"]`).hasText('true');
 
-        } else if (meetsBreakpoint === false) {
-          assert.dom(`[data-test-breakpoint="${name}"]`).hasText('false');
+        } else if (meetsFeature === false) {
+          assert.dom(`[data-test-feature="${name}"]`).hasText('false');
 
-        } else if (!meetsBreakpoint) {
-          assert.dom(`[data-test-breakpoint="${name}"]`).hasNoText();
+        } else if (!meetsFeature) {
+          assert.dom(`[data-test-feature="${name}"]`).hasNoText();
 
         }
       }
@@ -25,32 +25,32 @@ module('@desktop Integration | Component | container-query', function(hooks) {
   });
 
   hooks.afterEach(function(assert) {
-    delete assert.areBreakpointsCorrect;
+    delete assert.areFeaturesCorrect;
   });
 
 
-  module('When @breakpoints is undefined', function() {
+  module('When @features is undefined', function() {
     test('The component renders', async function(assert) {
       await render(hbs`
         <div style="width: 500px; height: 800px;">
           <ContainerQuery
             as |CQ|
           >
-            <p data-test-breakpoint="small">{{CQ.breakpoints.small}}</p>
-            <p data-test-breakpoint="medium">{{CQ.breakpoints.medium}}</p>
-            <p data-test-breakpoint="large">{{CQ.breakpoints.large}}</p>
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
 
-            <p data-test-breakpoint="short">{{CQ.breakpoints.short}}</p>
-            <p data-test-breakpoint="tall">{{CQ.breakpoints.tall}}</p>
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
 
-            <p data-test-breakpoint="ratio-type-A">{{CQ.breakpoints.ratio-type-A}}</p>
-            <p data-test-breakpoint="ratio-type-B">{{CQ.breakpoints.ratio-type-B}}</p>
-            <p data-test-breakpoint="ratio-type-C">{{CQ.breakpoints.ratio-type-C}}</p>
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
           </ContainerQuery>
         </div>
       `);
 
-      assert.areBreakpointsCorrect({
+      assert.areFeaturesCorrect({
         small: undefined,
         medium: undefined,
         large: undefined,
@@ -63,7 +63,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
     });
 
 
-    test('The component updates this.breakpoints when it is resized', async function(assert) {
+    test('The component updates this.features when it is resized', async function(assert) {
       await render(hbs`
         <div
           data-test-parent-element
@@ -72,21 +72,21 @@ module('@desktop Integration | Component | container-query', function(hooks) {
           <ContainerQuery
             as |CQ|
           >
-            <p data-test-breakpoint="small">{{CQ.breakpoints.small}}</p>
-            <p data-test-breakpoint="medium">{{CQ.breakpoints.medium}}</p>
-            <p data-test-breakpoint="large">{{CQ.breakpoints.large}}</p>
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
 
-            <p data-test-breakpoint="short">{{CQ.breakpoints.short}}</p>
-            <p data-test-breakpoint="tall">{{CQ.breakpoints.tall}}</p>
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
 
-            <p data-test-breakpoint="ratio-type-A">{{CQ.breakpoints.ratio-type-A}}</p>
-            <p data-test-breakpoint="ratio-type-B">{{CQ.breakpoints.ratio-type-B}}</p>
-            <p data-test-breakpoint="ratio-type-C">{{CQ.breakpoints.ratio-type-C}}</p>
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
           </ContainerQuery>
         </div>
       `);
 
-      assert.areBreakpointsCorrect({
+      assert.areFeaturesCorrect({
         small: undefined,
         medium: undefined,
         large: undefined,
@@ -100,7 +100,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
 
       await resizeWindow(500, 300);
 
-      assert.areBreakpointsCorrect({
+      assert.areFeaturesCorrect({
         small: undefined,
         medium: undefined,
         large: undefined,
@@ -114,7 +114,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
 
       await resizeWindow(800, 400);
 
-      assert.areBreakpointsCorrect({
+      assert.areFeaturesCorrect({
         small: undefined,
         medium: undefined,
         large: undefined,
@@ -128,7 +128,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
 
       await resizeWindow(1000, 600);
 
-      assert.areBreakpointsCorrect({
+      assert.areFeaturesCorrect({
         small: undefined,
         medium: undefined,
         large: undefined,
@@ -142,12 +142,12 @@ module('@desktop Integration | Component | container-query', function(hooks) {
   });
 
 
-  module('When @breakpoints is passed', function() {
+  module('When @features is passed', function() {
     test('The component renders', async function(assert) {
       await render(hbs`
         <div style="width: 500px; height: 800px;">
           <ContainerQuery
-            @breakpoints={{hash
+            @features={{hash
               small=(cq-width max=300)
               medium=(cq-width min=300 max=600)
               large=(cq-width min=600 max=900)
@@ -159,21 +159,21 @@ module('@desktop Integration | Component | container-query', function(hooks) {
             }}
             as |CQ|
           >
-            <p data-test-breakpoint="small">{{CQ.breakpoints.small}}</p>
-            <p data-test-breakpoint="medium">{{CQ.breakpoints.medium}}</p>
-            <p data-test-breakpoint="large">{{CQ.breakpoints.large}}</p>
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
 
-            <p data-test-breakpoint="short">{{CQ.breakpoints.short}}</p>
-            <p data-test-breakpoint="tall">{{CQ.breakpoints.tall}}</p>
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
 
-            <p data-test-breakpoint="ratio-type-A">{{CQ.breakpoints.ratio-type-A}}</p>
-            <p data-test-breakpoint="ratio-type-B">{{CQ.breakpoints.ratio-type-B}}</p>
-            <p data-test-breakpoint="ratio-type-C">{{CQ.breakpoints.ratio-type-C}}</p>
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
           </ContainerQuery>
         </div>
       `);
 
-      assert.areBreakpointsCorrect({
+      assert.areFeaturesCorrect({
         small: false,
         medium: true,
         large: false,
@@ -186,14 +186,14 @@ module('@desktop Integration | Component | container-query', function(hooks) {
     });
 
 
-    test('The component updates this.breakpoints when it is resized', async function(assert) {
+    test('The component updates this.features when it is resized', async function(assert) {
       await render(hbs`
         <div
           data-test-parent-element
           style="width: 250px; height: 500px;"
         >
           <ContainerQuery
-            @breakpoints={{hash
+            @features={{hash
               small=(cq-width max=300)
               medium=(cq-width min=300 max=600)
               large=(cq-width min=600 max=900)
@@ -205,21 +205,21 @@ module('@desktop Integration | Component | container-query', function(hooks) {
             }}
             as |CQ|
           >
-            <p data-test-breakpoint="small">{{CQ.breakpoints.small}}</p>
-            <p data-test-breakpoint="medium">{{CQ.breakpoints.medium}}</p>
-            <p data-test-breakpoint="large">{{CQ.breakpoints.large}}</p>
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
 
-            <p data-test-breakpoint="short">{{CQ.breakpoints.short}}</p>
-            <p data-test-breakpoint="tall">{{CQ.breakpoints.tall}}</p>
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
 
-            <p data-test-breakpoint="ratio-type-A">{{CQ.breakpoints.ratio-type-A}}</p>
-            <p data-test-breakpoint="ratio-type-B">{{CQ.breakpoints.ratio-type-B}}</p>
-            <p data-test-breakpoint="ratio-type-C">{{CQ.breakpoints.ratio-type-C}}</p>
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
           </ContainerQuery>
         </div>
       `);
 
-      assert.areBreakpointsCorrect({
+      assert.areFeaturesCorrect({
         small: true,
         medium: false,
         large: false,
@@ -233,7 +233,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
 
       await resizeWindow(500, 300);
 
-      assert.areBreakpointsCorrect({
+      assert.areFeaturesCorrect({
         small: false,
         medium: true,
         large: false,
@@ -247,7 +247,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
 
       await resizeWindow(800, 400);
 
-      assert.areBreakpointsCorrect({
+      assert.areFeaturesCorrect({
         small: false,
         medium: false,
         large: true,
@@ -261,7 +261,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
 
       await resizeWindow(1000, 600);
 
-      assert.areBreakpointsCorrect({
+      assert.areFeaturesCorrect({
         small: false,
         medium: false,
         large: false,
@@ -283,7 +283,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
           style="width: 250px; height: 500px;"
         >
           <ContainerQuery
-            @breakpoints={{hash
+            @features={{hash
               small=(cq-width max=300)
               medium=(cq-width min=300 max=600)
               large=(cq-width min=600 max=900)
@@ -295,16 +295,16 @@ module('@desktop Integration | Component | container-query', function(hooks) {
             }}
             as |CQ|
           >
-            <p data-test-breakpoint="small">{{CQ.breakpoints.small}}</p>
-            <p data-test-breakpoint="medium">{{CQ.breakpoints.medium}}</p>
-            <p data-test-breakpoint="large">{{CQ.breakpoints.large}}</p>
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
 
-            <p data-test-breakpoint="short">{{CQ.breakpoints.short}}</p>
-            <p data-test-breakpoint="tall">{{CQ.breakpoints.tall}}</p>
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
 
-            <p data-test-breakpoint="ratio-type-A">{{CQ.breakpoints.ratio-type-A}}</p>
-            <p data-test-breakpoint="ratio-type-B">{{CQ.breakpoints.ratio-type-B}}</p>
-            <p data-test-breakpoint="ratio-type-C">{{CQ.breakpoints.ratio-type-C}}</p>
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
           </ContainerQuery>
         </div>
       `);
@@ -369,7 +369,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
           style="width: 250px; height: 500px;"
         >
           <ContainerQuery
-            @breakpoints={{hash
+            @features={{hash
               small=(cq-width max=300)
               medium=(cq-width min=300 max=600)
               large=(cq-width min=600 max=900)
@@ -382,16 +382,16 @@ module('@desktop Integration | Component | container-query', function(hooks) {
             @dataAttributePrefix="cq"
             as |CQ|
           >
-            <p data-test-breakpoint="small">{{CQ.breakpoints.small}}</p>
-            <p data-test-breakpoint="medium">{{CQ.breakpoints.medium}}</p>
-            <p data-test-breakpoint="large">{{CQ.breakpoints.large}}</p>
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
 
-            <p data-test-breakpoint="short">{{CQ.breakpoints.short}}</p>
-            <p data-test-breakpoint="tall">{{CQ.breakpoints.tall}}</p>
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
 
-            <p data-test-breakpoint="ratio-type-A">{{CQ.breakpoints.ratio-type-A}}</p>
-            <p data-test-breakpoint="ratio-type-B">{{CQ.breakpoints.ratio-type-B}}</p>
-            <p data-test-breakpoint="ratio-type-C">{{CQ.breakpoints.ratio-type-C}}</p>
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
           </ContainerQuery>
         </div>
       `);
@@ -459,7 +459,7 @@ module('@desktop Integration | Component | container-query', function(hooks) {
       await render(hbs`
         <div style="width: 500px; height: 800px;">
           <ContainerQuery
-            @breakpoints={{hash
+            @features={{hash
               small=(cq-width max=300)
               medium=(cq-width min=300 max=600)
               large=(cq-width min=600 max=900)
@@ -476,16 +476,16 @@ module('@desktop Integration | Component | container-query', function(hooks) {
 
             as |CQ|
           >
-            <p data-test-breakpoint="small">{{CQ.breakpoints.small}}</p>
-            <p data-test-breakpoint="medium">{{CQ.breakpoints.medium}}</p>
-            <p data-test-breakpoint="large">{{CQ.breakpoints.large}}</p>
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
 
-            <p data-test-breakpoint="short">{{CQ.breakpoints.short}}</p>
-            <p data-test-breakpoint="tall">{{CQ.breakpoints.tall}}</p>
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
 
-            <p data-test-breakpoint="ratio-type-A">{{CQ.breakpoints.ratio-type-A}}</p>
-            <p data-test-breakpoint="ratio-type-B">{{CQ.breakpoints.ratio-type-B}}</p>
-            <p data-test-breakpoint="ratio-type-C">{{CQ.breakpoints.ratio-type-C}}</p>
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
           </ContainerQuery>
         </div>
       `);

--- a/tests/integration/components/tracks-test.js
+++ b/tests/integration/components/tracks-test.js
@@ -14,7 +14,7 @@ module('@desktop Integration | Component | tracks', function(hooks) {
 
 
   test('uses container queries to render tracks', async function(assert) {
-    // Breakpoints: small, short
+    // Features: small, short
     await render(hbs`
       <div
         data-test-parent-element
@@ -34,7 +34,7 @@ module('@desktop Integration | Component | tracks', function(hooks) {
       .doesNotExist('We don\'t see a table.');
 
 
-    // Breakpoints: medium, short
+    // Features: medium, short
     await resizeWindow(560, 240);
 
     assert.dom('[data-test-list="Tracks"]')
@@ -45,7 +45,7 @@ module('@desktop Integration | Component | tracks', function(hooks) {
       .doesNotExist('We don\'t see a table.');
 
 
-    // Breakpoints: large, short
+    // Features: large, short
     await resizeWindow(880, 240);
 
     assert.dom('[data-test-list="Tracks"]')
@@ -56,7 +56,7 @@ module('@desktop Integration | Component | tracks', function(hooks) {
       .doesNotExist('We don\'t see a table.');
 
 
-    // Breakpoints: small, tall
+    // Features: small, tall
     await resizeWindow(240, 640);
 
     assert.dom('[data-test-list="Tracks"]')
@@ -67,7 +67,7 @@ module('@desktop Integration | Component | tracks', function(hooks) {
       .doesNotExist('We don\'t see a table.');
 
 
-    // Breakpoints: medium, tall
+    // Features: medium, tall
     await resizeWindow(560, 640);
 
     assert.dom('[data-test-list="Tracks"]')
@@ -78,7 +78,7 @@ module('@desktop Integration | Component | tracks', function(hooks) {
       .doesNotExist('We don\'t see a table.');
 
 
-    // Breakpoints: large, tall
+    // Features: large, tall
     await resizeWindow(880, 640);
 
     assert.dom('[data-test-list="Tracks"]')


### PR DESCRIPTION
## Description

I used the name `breakpoints` to provide an API similar to `ember-fill-up`'s. After I introduced the aspect ratio in #3, it didn't make sense to keep using the name `breakpoints`.

[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries) uses the term `features`, which I liked:

> _Media features_ describe specific characteristics of the user agent, output device, or environment. Media feature expressions test for their presence or value, and are entirely optional. Each media feature expression must be surrounded by parentheses.