### PR TITLE
Applied .full-screen class to div#ember-testing-container

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -42,9 +42,10 @@ const { DEVICE = 'w3-h3' } = process.env;
 
 const filter = encodeURIComponent(FILTERS[DEVICE]);
 const windowSize = WINDOW_SIZES[DEVICE];
+const [width, height] = windowSize.split(',');
 
 module.exports = {
-  test_page: `tests/index.html?filter=${filter}&hidepassed&nolint`,
+  test_page: `tests/index.html?filter=${filter}&width=${width}&height=${height}&hidepassed&nolint`,
   disable_watching: true,
   launch_in_ci: [
     'Chrome'

--- a/tests/acceptance/album-test.js
+++ b/tests/acceptance/album-test.js
@@ -1,15 +1,142 @@
 import { visit } from '@ember/test-helpers';
 import takeSnapshot from 'dummy/tests/helpers/percy';
+import resetViewport from 'dummy/tests/helpers/reset-viewport';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Acceptance | album', function(hooks) {
   setupApplicationTest(hooks);
+  resetViewport(hooks);
 
-  test('Album example', async function(assert) {
+
+  test('@w1 @h1 Visual snapshot', async function(assert) {
     await visit('/album');
-    await takeSnapshot(assert);
 
-    assert.ok(true);
+    assert.dom('[data-test-list="Tracks"]')
+      .exists('We see the album tracks in a list.')
+      .hasAttribute('data-css-grid', '11 x 1', 'We see 11 tracks in an 11 x 1 grid.');
+
+    assert.dom('[data-test-track-lyrics]')
+      .doesNotExist('We don\'t see the current track\'s lyrics.');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w2 @h1 Visual snapshot', async function(assert) {
+    await visit('/album');
+
+    assert.dom('[data-test-list="Tracks"]')
+      .exists('We see the album tracks in a list.')
+      .hasAttribute('data-css-grid', '4 x 3', 'We see 11 tracks in a 4 x 3 grid.');
+
+    assert.dom('[data-test-track-lyrics]')
+      .doesNotExist('We don\'t see the current track\'s lyrics.');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w3 @h1 Visual snapshot', async function(assert) {
+    await visit('/album');
+
+    assert.dom('[data-test-list="Tracks"]')
+      .exists('We see the album tracks in a list.')
+      .hasAttribute('data-css-grid', '4 x 3', 'We see 11 tracks in a 4 x 3 grid.');
+
+    assert.dom('[data-test-track-lyrics]')
+      .doesNotExist('We don\'t see the current track\'s lyrics.');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w1 @h2 Visual snapshot', async function(assert) {
+    await visit('/album');
+
+    assert.dom('[data-test-list="Tracks"]')
+      .exists('We see the album tracks in a list.')
+      .hasAttribute('data-css-grid', '11 x 1', 'We see 11 tracks in an 11 x 1 grid.');
+
+    assert.dom('[data-test-track-lyrics]')
+      .doesNotExist('We don\'t see the current track\'s lyrics.');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w2 @h2 Visual snapshot', async function(assert) {
+    await visit('/album');
+
+    assert.dom('[data-test-list="Tracks"]')
+      .exists('We see the album tracks in a list.')
+      .hasAttribute('data-css-grid', '4 x 3', 'We see 11 tracks in a 4 x 3 grid.');
+
+    assert.dom('[data-test-track-lyrics]')
+      .doesNotExist('We don\'t see the current track\'s lyrics.');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w3 @h2 Visual snapshot', async function(assert) {
+    await visit('/album');
+
+    assert.dom('[data-test-table="Tracks"]')
+      .exists('We see the album tracks in a table.');
+
+    assert.dom('[data-test-table="Tracks"] [data-test-row]')
+      .exists({ count: 11 }, 'We see 11 tracks.');
+
+    assert.dom('[data-test-track-lyrics]')
+      .exists('We see the current track\'s lyrics.');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w1 @h3 Visual snapshot', async function(assert) {
+    await visit('/album');
+
+    assert.dom('[data-test-list="Tracks"]')
+      .exists('We see the album tracks in a list.')
+      .hasAttribute('data-css-grid', '11 x 1', 'We see 11 tracks in an 11 x 1 grid.');
+
+    assert.dom('[data-test-track-lyrics]')
+      .doesNotExist('We don\'t see the current track\'s lyrics.');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w2 @h3 Visual snapshot', async function(assert) {
+    await visit('/album');
+
+    assert.dom('[data-test-table="Tracks"]')
+      .exists('We see the album tracks in a table.');
+
+    assert.dom('[data-test-table="Tracks"] [data-test-row]')
+      .exists({ count: 11 }, 'We see 11 tracks.');
+
+    assert.dom('[data-test-track-lyrics]')
+      .doesNotExist('We don\'t see the current track\'s lyrics.');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w3 @h3 Visual snapshot', async function(assert) {
+    await visit('/album');
+
+    assert.dom('[data-test-table="Tracks"]')
+      .exists('We see the album tracks in a table.');
+
+    assert.dom('[data-test-table="Tracks"] [data-test-row]')
+      .exists({ count: 11 }, 'We see 11 tracks.');
+
+    assert.dom('[data-test-track-lyrics]')
+      .exists('We see the current track\'s lyrics.');
+
+    await takeSnapshot(assert);
   });
 });

--- a/tests/dummy/app/styles/application.css
+++ b/tests/dummy/app/styles/application.css
@@ -11,13 +11,13 @@
   width: 100vw;
 }
 
-.header {
+.application .header {
   grid-area: header;
   min-height: 2.75rem;
   overflow-x: auto;
 }
 
-.main {
+.application .main {
   background-color: rgba(255, 255, 255, 0.045);
   border-bottom: 0.0625rem solid rgba(211, 211, 211, 0.15);
   border-top: 0.0625rem solid rgba(211, 211, 211, 0.15);
@@ -29,7 +29,7 @@
   overflow-y: hidden;
 }
 
-.main .center {
+.application .main .center {
   display: flex;
   flex-direction: column;
   max-width: 75rem;
@@ -37,7 +37,7 @@
   width: 100%;
 }
 
-.footer {
+.application .footer {
   align-items: center;
   display: flex;
   grid-area: footer;
@@ -45,12 +45,12 @@
   min-height: 2.375rem;
 }
 
-.footer .copyright {
+.application .footer .copyright {
   color: rgba(128, 191, 255, 0.9);
   font-size: 0.75rem;
   padding: 0.75rem 0;
 }
 
-.footer .copyright .link {
+.application .footer .copyright .link {
   color: rgba(128, 191, 255, 0.9);
 }

--- a/tests/dummy/app/templates/album.hbs
+++ b/tests/dummy/app/templates/album.hbs
@@ -29,7 +29,11 @@
       </div>
 
       {{#if showLyrics}}
-        <div local-class="track-lyrics" tabindex="0">
+        <div
+          data-test-track-lyrics
+          local-class="track-lyrics"
+          tabindex="0"
+        >
           <p local-class="heading-2">Lyrics</p>
 
           <div>

--- a/tests/helpers/percy.js
+++ b/tests/helpers/percy.js
@@ -2,17 +2,17 @@ import { assert } from '@ember/debug';
 import percySnapshot from '@percy/ember';
 
 const DEVICES = {
-    '400,300': 'w1-h1',
-    '900,300': 'w2-h1',
-    '1400,300': 'w3-h1',
+  '400,300': 'w1-h1',
+  '900,300': 'w2-h1',
+  '1400,300': 'w3-h1',
 
-    '400,600': 'w1-h2',
-    '900,600': 'w2-h2',
-    '1400,600': 'w3-h2',
+  '400,600': 'w1-h2',
+  '900,600': 'w2-h2',
+  '1400,600': 'w3-h2',
 
-    '400,900': 'w1-h3',
-    '900,900': 'w2-h3',
-    '1400,900': 'w3-h3'
+  '400,900': 'w1-h3',
+  '900,900': 'w2-h3',
+  '1400,900': 'w3-h3'
 };
 
 const supportedDevices = Object.values(DEVICES);
@@ -20,146 +20,146 @@ const supportedFilters = /(@w1\s+|@w2\s+|@w3\s+|@h1\s+|@h2\s+|@w3\s+)/g;
 
 
 /*
-    `takeSnapshot` is designed to ensure that,
+  `takeSnapshot` is designed to ensure that,
 
-    - Percy snapshot respects the test window width.
-    - Percy snapshots have unique names when a test can be run on multiple devices.
+  - Percy snapshot respects the test window width.
+  - Percy snapshots have unique names when a test can be run on multiple devices.
 
 
-    Examples:
+  Examples:
 
-    // Pass `assert` to capture a user's workflow.
-    test('A user can visit the homepage', async function(assert) {
-        await visit('/');
-        await takeSnapshot(assert);
+  // Pass `assert` to capture a user's workflow.
+  test('A user can visit the homepage', async function(assert) {
+    await visit('/');
+    await takeSnapshot(assert);
+  });
+
+  // Pass `description` to capture many steps of a user's workflow.
+  // Pass `only` to allow snapshots on some devices.
+  test('A user can create an account', async function(assert) {
+    ...
+
+    await takeSnapshot(assert, {
+      description: 'Fills out form'
     });
 
-    // Pass `description` to capture many steps of a user's workflow.
-    // Pass `only` to allow snapshots on some devices.
-    test('A user can create an account', async function(assert) {
-        ...
+    await click('[data-test-button="Submit"]');
 
-        await takeSnapshot(assert, {
-            description: 'Fills out form'
-        });
-
-        await click('[data-test-button="Submit"]');
-
-        await takeSnapshot(assert, {
-            description: 'Sees success toast',
-            only: ['w3-h3']
-        });
-
-        ...
+    await takeSnapshot(assert, {
+      description: 'Sees success toast',
+      only: ['w3-h3']
     });
+
+    ...
+  });
 */
 export default async function takeSnapshot(qunitAssert, options = {}) {
-    checkInput(qunitAssert, options);
+  checkInput(qunitAssert, options);
 
-    const { description, only } = options;
-    const skipSnapshot = only && !only.includes(getDevice());
+  const { description, only } = options;
+  const skipSnapshot = only && !only.includes(getDevice());
 
-    if (skipSnapshot) {
-        return;
-    }
+  if (skipSnapshot) {
+    return;
+  }
 
-    const name = getName(qunitAssert, description);
-    const width = getWidth();
-    const height = getHeight();
+  const name = getName(qunitAssert, description);
+  const { height, width } = getWindowSize();
 
-    await percySnapshot(name, {
-        widths: [width],
-        minHeight: height,
-        percyCSS: '.application { height: 100vh; }'
-    });
+  await percySnapshot(name, {
+    widths: [width],
+    minHeight: height
+  });
 }
 
 
 function checkInput(qunitAssert, options) {
-    const { description, only } = options;
+  const { description, only } = options;
 
+  assert(
+    '`qunitAssert` must be QUnit\'s assert object.',
+    typeof qunitAssert === 'object' && !!qunitAssert.test
+  );
+
+  if (description !== undefined) {
     assert(
-        '`qunitAssert` must be QUnit\'s assert object.',
-        typeof qunitAssert === 'object' && !!qunitAssert.test
+      '`options.description` must be a string.',
+      typeof description === 'string'
     );
 
-    if (description !== undefined) {
-        assert(
-            '`options.description` must be a string.',
-            typeof description === 'string'
-        );
+    assert(
+      '`options.description` cannot be empty.',
+      description !== ''
+    );
+  }
 
-        assert(
-            '`options.description` cannot be empty.',
-            description !== ''
-        );
-    }
+  if (only !== undefined) {
+    assert(
+      '`options.only` must be an array of strings.',
+      Array.isArray(only)
+    );
 
-    if (only !== undefined) {
-        assert(
-            '`options.only` must be an array of strings.',
-            Array.isArray(only)
-        );
+    assert(
+      '`options.only` cannot be empty.',
+      only.length >= 1
+    );
 
-        assert(
-            '`options.only` cannot be empty.',
-            only.length >= 1
-        );
+    const listOfSupportedDevices = supportedDevices
+      .map(device => `'${device}'`)
+      .join(', ');
 
-        const listOfSupportedDevices = supportedDevices
-            .map(device => `'${device}'`)
-            .join(', ');
-
-        assert(
-            `\`options.only\` cannot include strings other than ${listOfSupportedDevices}.`,
-            only.every(device => supportedDevices.includes(device))
-        );
-    }
+    assert(
+      `\`options.only\` cannot include strings other than ${listOfSupportedDevices}.`,
+      only.every(device => supportedDevices.includes(device))
+    );
+  }
 }
 
 
 function getDevice() {
-    const windowSize = `${getWidth()},${getHeight()}`;
-    const device = DEVICES[windowSize];
+  const { height, width } = getWindowSize();
 
-    assert(
-        `Couldn't find device for window size ${windowSize}.`,
-        !!device
-    );
+  const windowSize = `${width},${height}`;
+  const device = DEVICES[windowSize];
 
-    return device;
+  assert(
+    `The window size is incorrect. Found ${windowSize}.`,
+    !!device
+  );
+
+  return device;
 }
 
 
 /*
-    `getName` creates the snapshot name in the following format:
+  `getName` creates the snapshot name in the following format:
 
-        @<device> ◆ <testName> - <description> ◆ <moduleName>
+    @<device> ◆ <testName> - <description> ◆ <moduleName>
 
-    Snapshot names are guaranteed to be unique if a test takes a snapshot
-    and the test can be run on multiple devices.
+  Snapshot names are guaranteed to be unique if a test takes a snapshot
+  and the test can be run on multiple devices.
 */
 function getName(qunitAssert, description) {
-    const moduleName = qunitAssert.test?.module?.name;
-    const testName = qunitAssert.test?.testName;
+  const moduleName = qunitAssert.test?.module?.name;
+  const testName = qunitAssert.test?.testName;
 
-    let name = testName;
+  let name = testName;
 
-    if (description) {
-        name += ` - ${description}`;
-    }
+  if (description) {
+    name += ` - ${description}`;
+  }
 
-    name += ` ◆ ${moduleName}`;
+  name += ` ◆ ${moduleName}`;
 
-    return `@${getDevice()} ◆ ${name.replace(supportedFilters, '')}`;
+  return `@${getDevice()} ◆ ${name.replace(supportedFilters, '')}`;
 }
 
 
-function getHeight() {
-    return window.innerHeight;
-}
+function getWindowSize() {
+  const queryParams = new URLSearchParams(window.location.search);
 
-
-function getWidth() {
-    return window.innerWidth;
+  return {
+    height: Number(queryParams.get('height')),
+    width: Number(queryParams.get('width'))
+  };
 }

--- a/tests/helpers/reset-viewport.js
+++ b/tests/helpers/reset-viewport.js
@@ -1,0 +1,12 @@
+/*
+  Do not allow ember-qunit to resize the viewport! Resizing the viewport causes
+  issues with tests and Percy snapshots for this addon.
+
+  https://github.com/emberjs/ember-qunit/blob/master/vendor/ember-qunit/test-container-styles.css
+*/
+export default function resetViewport(hooks) {
+  hooks.beforeEach(function() {
+    let testingContainer = document.getElementById('ember-testing-container');
+    testingContainer.classList.add('full-screen');
+  });
+}

--- a/tests/helpers/resize-window.js
+++ b/tests/helpers/resize-window.js
@@ -3,23 +3,23 @@ import { later } from '@ember/runloop';
 import { find } from '@ember/test-helpers';
 
 const timeout = milliseconds => {
-    return new Promise(resolve => {
-        later(resolve, milliseconds);
-    });
+  return new Promise(resolve => {
+    later(resolve, milliseconds);
+  });
 };
 
 const rerenderTime = 100;
 
 export default async function resizeWindow(width, height) {
-    let parentElement = find('[data-test-parent-element]');
+  let parentElement = find('[data-test-parent-element]');
 
-    assert(
-        'Please create a parent element with the test selector `data-test-parent-element`.',
-        !!parentElement
-    );
+  assert(
+    'Please create a parent element with the test selector `data-test-parent-element`.',
+    !!parentElement
+  );
 
-    parentElement.style.width = `${width}px`;
-    parentElement.style.height = `${height}px`;
+  parentElement.style.width = `${width}px`;
+  parentElement.style.height = `${height}px`;
 
-    await timeout(rerenderTime);
+  await timeout(rerenderTime);
 }


### PR DESCRIPTION
## Description

For the longest time, I had trouble getting Percy snapshots to look like what I'd see in the browser. The culprit turned out to be `ember-qunit`. It resizes the viewport so that the application can be shown in a browser along with the menu.

Resizing the viewport can cause tests and Percy snapshots to fail. This is especially true for this addon, because the addon assumes that a parent element's width and height (e.g. starting with `div.ember-application`) is correct to begin with.

The solution was to add `.full-screen` class to the element `div.ember-application`. (This element is equivalent to `div#ember-testing-container`.)

Note, `ember-qunit` allows the URL query parameter `devmode` to add this CSS class. However, doing so would prevent developers from easily debugging tests in their browser.


## References

https://github.com/emberjs/ember-qunit/blob/master/vendor/ember-qunit/test-container-styles.css#L32-L44