### PR TITLE
Simplified stylesheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,12 @@ It also accepts these arguments:
 | @dataAttributePrefix | No | Prefix for data attributes | string |
 | @debounce | No | Debounce time (ms) for resize | number ≥ 0 |
 
-The component returns a few values that you can consume:
+The component returns two values that you can consume:
 
 | Name | Yielded | Description |
 |--|:--:|--|
 | features | Yes | Container query results |
 | data-container-query-_{featureName}_ | No | Data attributes for CSS selector |
-| data-test-container-query | No | Test selector |
 
 <sup>1. Do refrain from overusing splattributes (e.g. pass a `{{did-insert}}` modifier to fetch data), since the component's API may change and cause unexpected results. Practice separation of concerns when possible. For example, data fetching can be handled by another element or [`@use` decorator](https://github.com/emberjs/rfcs/blob/use-and-resources/text/0567-use-and-resources.md).</sup>
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "@ember/render-modifiers": "^1.0.2",
     "ember-cli-babel": "^7.19.0",
     "ember-cli-htmlbars": "^5.1.2",
-    "ember-did-resize-modifier": "^1.0.0",
-    "ember-test-selectors": "^4.1.0"
+    "ember-did-resize-modifier": "^1.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
@@ -65,6 +64,7 @@
     "ember-source": "~3.18.0",
     "ember-source-channel-url": "^2.0.1",
     "ember-template-lint": "^2.7.0",
+    "ember-test-selectors": "^4.1.0",
     "ember-try": "^1.4.0",
     "eslint": "^7.0.0",
     "eslint-plugin-ember": "^8.4.0",

--- a/tests/dummy/app/components/navigation-menu/index.css
+++ b/tests/dummy/app/components/navigation-menu/index.css
@@ -3,7 +3,11 @@
   display: flex;
 }
 
-.item a {
+.item.active-route {
+  background-color: rgba(255, 255, 255, 0.075);
+}
+
+.link {
   display: inline-block;
   font-size: 0.875rem;
   padding: 0.875rem 1rem;
@@ -11,11 +15,7 @@
   white-space: nowrap;
 }
 
-.item a:hover {
+.link:hover {
   background-color: rgba(255, 255, 255, 0.075);
   transition: background-color 0.17s;
-}
-
-.item.active-route {
-  background-color: rgba(255, 255, 255, 0.075);
 }

--- a/tests/dummy/app/components/navigation-menu/index.hbs
+++ b/tests/dummy/app/components/navigation-menu/index.hbs
@@ -7,6 +7,7 @@
       <li local-class="item {{if (eq menuItem.route this.rootRoute) "active-route"}}">
         <LinkTo
           data-test-link={{menuItem.label}}
+          local-class="link"
           @route={{menuItem.route}}
         >
           {{menuItem.label}}

--- a/tests/dummy/app/components/tracks/list/index.css
+++ b/tests/dummy/app/components/tracks/list/index.css
@@ -18,7 +18,3 @@
   flex-shrink: 0;
   margin-left: 0.25rem;
 }
-
-.item:last-of-type {
-  margin-bottom: 0;
-}

--- a/tests/dummy/app/components/tracks/table/index.hbs
+++ b/tests/dummy/app/components/tracks/table/index.hbs
@@ -1,5 +1,5 @@
 <table data-test-table="Tracks">
-  <thead local-class="header">
+  <thead>
     <tr>
       <th local-class="track-number">#</th>
       <th local-class="track-name">Title</th>

--- a/tests/dummy/app/styles/album.css
+++ b/tests/dummy/app/styles/album.css
@@ -10,38 +10,38 @@
   padding: 1.5rem 1rem;
 }
 
-.container .album-header {
+.album-header {
   grid-area: album-header;
 }
 
-.container .album-tracks {
+.album-tracks {
   grid-area: album-tracks;
   margin-top: 1rem;
   margin-bottom: 2rem;
 }
 
-.container .track-lyrics {
+.track-lyrics {
   grid-area: track-lyrics;
   overflow-y: auto;
   padding-right: 1rem;
 }
 
-.container .track-lyrics .heading-2 {
+.track-lyrics .heading-2 {
   font-size: 1.25rem;
   font-weight: 700;
   margin-bottom: 0.75rem;
 }
 
-.container .track-lyrics .heading-3 {
+.track-lyrics .heading-3 {
   color: goldenrod;
 }
 
-.container .track-lyrics .lyrics {
+.track-lyrics .lyrics {
   font-size: 0.8rem;
   line-height: 1.75;
 }
 
-.container.with-lyrics {
+.with-lyrics {
   grid-column-gap: 2rem;
   grid-template-areas:
     "album-header track-lyrics"
@@ -51,7 +51,7 @@
   overflow-y: hidden;
 }
 
-.container.with-lyrics .album-tracks {
+.with-lyrics .album-tracks {
   margin-bottom: 0;
   overflow-y: auto;
 }

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -13,49 +13,48 @@ body {
   margin: 0;
 }
 
-body * {
+* {
   margin: 0;
   padding: 0;
 }
 
-body h1 {
+h1 {
   font-size: 2.25em;
   font-weight: 700;
   margin-bottom: 1.5rem;
 }
 
-body h2 {
+h2 {
   font-size: 1.5rem;
   font-weight: 700;
   margin-bottom: 1rem;
 }
 
-body h3 {
+h3 {
   font-size: 1.25rem;
   font-weight: 700;
   margin-bottom: 0.75rem;
 }
 
-body a {
+a {
   color: rgba(245, 255, 250, 0.88);
 }
 
-body p {
+p {
   margin-bottom: 0.75rem;
 }
 
-body table {
+table {
   border-collapse: collapse;
   width: 100%;
 }
 
-body table th,
-body table td {
+th, td {
   border: 0.0625rem solid rgba(112, 128, 144, 1);
   padding: 0.25rem 0.5rem;
 }
 
-body ul {
+ul {
   list-style-type: none;
 }
 

--- a/tests/dummy/app/styles/application.css
+++ b/tests/dummy/app/styles/application.css
@@ -11,13 +11,13 @@
   width: 100vw;
 }
 
-.application .header {
+.header {
   grid-area: header;
   min-height: 2.75rem;
   overflow-x: auto;
 }
 
-.application .main {
+.main {
   background-color: rgba(255, 255, 255, 0.045);
   border-bottom: 0.0625rem solid rgba(211, 211, 211, 0.15);
   border-top: 0.0625rem solid rgba(211, 211, 211, 0.15);
@@ -29,7 +29,7 @@
   overflow-y: hidden;
 }
 
-.application .main .center {
+.center {
   display: flex;
   flex-direction: column;
   max-width: 75rem;
@@ -37,7 +37,7 @@
   width: 100%;
 }
 
-.application .footer {
+.footer {
   align-items: center;
   display: flex;
   grid-area: footer;
@@ -45,12 +45,12 @@
   min-height: 2.375rem;
 }
 
-.application .footer .copyright {
+.copyright {
   color: rgba(128, 191, 255, 0.9);
   font-size: 0.75rem;
   padding: 0.75rem 0;
 }
 
-.application .footer .copyright .link {
+.copyright .link {
   color: rgba(128, 191, 255, 0.9);
 }


### PR DESCRIPTION
## Description

In #8, I thought nesting would help, but I think we shouldn't need it when we use `ember-css-modules`. I decided to remove it so that there's one fewer dependency to manage over time.

I also moved `ember-test-selectors` to `devDependencies` so that a user is less likely to use `data-test-container-query` in their tests. Let's encourage them to rely on the addon's API (i.e. the yielded `features` and data attributes).