### PR TITLE
Created Dashboard example (Part 1 of 5)

### DIFF
--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -1,0 +1,118 @@
+import { visit } from '@ember/test-helpers';
+import takeSnapshot from 'dummy/tests/helpers/percy';
+import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Acceptance | dashboard', function(hooks) {
+  setupApplicationTest(hooks);
+  resetViewport(hooks);
+
+
+  test('@w1 @h1 Visual snapshot', async function(assert) {
+    await visit('/dashboard');
+
+    assert.dom('[data-test-widget="1"] [data-test-container-query]')
+      .doesNotHaveAttribute('data-container-query-tall')
+      .doesNotHaveAttribute('data-container-query-square')
+      .hasAttribute('data-container-query-wide');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w2 @h1 Visual snapshot', async function(assert) {
+    await visit('/dashboard');
+
+    assert.dom('[data-test-widget="1"] [data-test-container-query]')
+      .doesNotHaveAttribute('data-container-query-tall')
+      .hasAttribute('data-container-query-square')
+      .doesNotHaveAttribute('data-container-query-wide');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w3 @h1 Visual snapshot', async function(assert) {
+    await visit('/dashboard');
+
+    assert.dom('[data-test-widget="1"] [data-test-container-query]')
+      .hasAttribute('data-container-query-tall')
+      .doesNotHaveAttribute('data-container-query-square')
+      .doesNotHaveAttribute('data-container-query-wide');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w1 @h2 Visual snapshot', async function(assert) {
+    await visit('/dashboard');
+
+    assert.dom('[data-test-widget="1"] [data-test-container-query]')
+      .doesNotHaveAttribute('data-container-query-tall')
+      .doesNotHaveAttribute('data-container-query-square')
+      .hasAttribute('data-container-query-wide');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w2 @h2 Visual snapshot', async function(assert) {
+    await visit('/dashboard');
+
+    assert.dom('[data-test-widget="1"] [data-test-container-query]')
+      .doesNotHaveAttribute('data-container-query-tall')
+      .hasAttribute('data-container-query-square')
+      .doesNotHaveAttribute('data-container-query-wide');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w3 @h2 Visual snapshot', async function(assert) {
+    await visit('/dashboard');
+
+    assert.dom('[data-test-widget="1"] [data-test-container-query]')
+      .hasAttribute('data-container-query-tall')
+      .doesNotHaveAttribute('data-container-query-square')
+      .doesNotHaveAttribute('data-container-query-wide');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w1 @h3 Visual snapshot', async function(assert) {
+    await visit('/dashboard');
+
+    assert.dom('[data-test-widget="1"] [data-test-container-query]')
+      .doesNotHaveAttribute('data-container-query-tall')
+      .doesNotHaveAttribute('data-container-query-square')
+      .hasAttribute('data-container-query-wide');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w2 @h3 Visual snapshot', async function(assert) {
+    await visit('/dashboard');
+
+    assert.dom('[data-test-widget="1"] [data-test-container-query]')
+      .doesNotHaveAttribute('data-container-query-tall')
+      .hasAttribute('data-container-query-square')
+      .doesNotHaveAttribute('data-container-query-wide');
+
+    await takeSnapshot(assert);
+  });
+
+
+  test('@w3 @h3 Visual snapshot', async function(assert) {
+    await visit('/dashboard');
+
+    assert.dom('[data-test-widget="1"] [data-test-container-query]')
+      .hasAttribute('data-container-query-tall')
+      .doesNotHaveAttribute('data-container-query-square')
+      .doesNotHaveAttribute('data-container-query-wide');
+
+    await takeSnapshot(assert);
+  });
+});

--- a/tests/dummy/app/components/widgets/widget-1/index.css
+++ b/tests/dummy/app/components/widgets/widget-1/index.css
@@ -1,0 +1,47 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.items {
+  display: grid;
+  grid-gap: 0.6rem;
+  flex: 1;
+}
+
+.item-1 {
+  grid-area: item-1;
+}
+
+.item-2 {
+  grid-area: item-2;
+}
+
+.item-3 {
+  grid-area: item-3;
+}
+
+.container[data-container-query-tall] .items {
+  grid-template-areas:
+    "item-1"
+    "item-2"
+    "item-3";
+  grid-template-columns: 1fr;
+  grid-template-rows: repeat(3, 1fr);
+}
+
+.container[data-container-query-square] .items {
+  grid-template-areas:
+    "item-1 item-2"
+    "item-3 item-3";
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+}
+
+.container[data-container-query-wide] .items {
+  grid-template-areas:
+    "item-1 item-2 item-3";
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: 1fr;
+}

--- a/tests/dummy/app/components/widgets/widget-1/index.hbs
+++ b/tests/dummy/app/components/widgets/widget-1/index.hbs
@@ -1,0 +1,32 @@
+<ContainerQuery
+  @features={{hash
+    tall=(cq-aspect-ratio max=0.8)
+    square=(cq-aspect-ratio min=0.8 max=1.25)
+    wide=(cq-aspect-ratio min=1.25)
+  }}
+  local-class="container"
+>
+  <header local-class="header">
+    <h2 local-class="text">Widget 1</h2>
+  </header>
+
+  <div local-class="items">
+    <div local-class="item-1">
+      <Widgets::Widget-1::Item
+        @label="Item 1"
+      />
+    </div>
+
+    <div local-class="item-2">
+      <Widgets::Widget-1::Item
+        @label="Item 2"
+      />
+    </div>
+
+    <div local-class="item-3">
+      <Widgets::Widget-1::Item
+        @label="Item 3"
+      />
+    </div>
+  </div>
+</ContainerQuery>

--- a/tests/dummy/app/components/widgets/widget-1/item/index.css
+++ b/tests/dummy/app/components/widgets/widget-1/item/index.css
@@ -1,0 +1,8 @@
+.container {
+  background: linear-gradient(36deg, rgba(255, 224, 130, 0.4) 15%, rgba(255, 248, 225, 0.8) 90%);
+  border-radius: 0.1875rem;
+  height: calc(100% - 1.2rem);
+  padding: 0.6rem;
+  width: calc(100% - 1.2rem);
+  word-break: break-word;
+}

--- a/tests/dummy/app/components/widgets/widget-1/item/index.hbs
+++ b/tests/dummy/app/components/widgets/widget-1/item/index.hbs
@@ -1,0 +1,3 @@
+<div local-class="container">
+  <p>{{@label}}</p>
+</div>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,4 +8,5 @@ export default class Router extends EmberRouter {
 
 Router.map(function() {
   this.route('album');
+  this.route('dashboard');
 });

--- a/tests/dummy/app/styles/dashboard.css
+++ b/tests/dummy/app/styles/dashboard.css
@@ -1,0 +1,95 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 1rem;
+}
+
+.widgets {
+  display: grid;
+  flex: 1;
+  grid-gap: 1rem;
+  grid-template-areas:
+    "widget-1"
+    "widget-2"
+    "widget-3"
+    "widget-4"
+    "widget-5";
+  grid-template-columns: 1fr;
+  grid-template-rows: repeat(4, minmax(12rem, 75%)) 5rem;
+}
+
+.widget-1, .widget-2, .widget-3, .widget-4, .widget-5 {
+  border-radius: 0.125rem;
+  overflow: hidden;
+  padding: 0.75rem;
+}
+
+.widget-1 {
+  background: linear-gradient(126deg, #e91e63 16%, #ff6090 84%);
+  grid-area: widget-1;
+}
+
+.widget-2 {
+  background: linear-gradient(126deg, #7cb342 16%, #aee571 84%);
+  grid-area: widget-2;
+}
+
+.widget-3 {
+  background: linear-gradient(126deg, #ffa000 16%, #ffd149 84%);
+  grid-area: widget-3;
+}
+
+.widget-4 {
+  background: linear-gradient(126deg, #29b6f6 16%, #73e8ff 84%);
+  grid-area: widget-4;
+}
+
+.widget-5 {
+  background: linear-gradient(126deg, #9c27b0 16%, #d05ce3 84%);
+  grid-area: widget-5;
+}
+
+
+@media screen and (min-width: 30rem) and (max-width: 60rem) {
+  .widgets {
+    grid-template-areas:
+      "widget-1 widget-2"
+      "widget-4 widget-2"
+      "widget-4 widget-3"
+      "widget-5 widget-3";
+    grid-template-columns: 2fr 5fr;
+    grid-template-rows: 15rem 5rem 10rem 5rem;
+  }
+
+  @media (min-height: 40rem) {
+    .container {
+      height: calc(100% - 3rem);
+    }
+
+    .widgets {
+      grid-template-rows: 3fr 1fr 2fr 5rem;
+    }
+  }
+}
+
+
+@media screen and (min-width: 60rem) {
+  .widgets {
+    grid-template-areas:
+      "widget-1 widget-2 widget-4"
+      "widget-3 widget-3 widget-4"
+      "widget-3 widget-3 widget-5";
+    grid-template-columns: minmax(25%, 15rem) minmax(50%, 15rem) auto;
+    grid-template-rows: 24rem 6rem 10rem;
+  }
+
+  @media (min-height: 40rem) {
+    .container {
+      height: calc(100% - 3rem);
+    }
+
+    .widgets {
+      grid-template-rows: 4fr 1fr 10rem;
+    }
+  }
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,6 +5,7 @@
       @menuItems={{array
         (hash route="index" label="Home")
         (hash route="album" label="Album")
+        (hash route="dashboard" label="Dashboard")
       }}
     />
   </header>

--- a/tests/dummy/app/templates/dashboard.hbs
+++ b/tests/dummy/app/templates/dashboard.hbs
@@ -4,7 +4,7 @@
   </header>
 
   <div local-class="widgets">
-    <div local-class="widget-1">
+    <div data-test-widget="1" local-class="widget-1">
       <Widgets::Widget-1 />
     </div>
 

--- a/tests/dummy/app/templates/dashboard.hbs
+++ b/tests/dummy/app/templates/dashboard.hbs
@@ -1,0 +1,27 @@
+<section local-class="container">
+  <header local-class="header">
+    <h1>Dashboard</h1>
+  </header>
+
+  <div local-class="widgets">
+    <div local-class="widget-1">
+      <Widgets::Widget-1 />
+    </div>
+
+    <div local-class="widget-2">
+      Widget 2
+    </div>
+
+    <div local-class="widget-3">
+      Widget 3
+    </div>
+
+    <div local-class="widget-4">
+      Widget 4
+    </div>
+
+    <div local-class="widget-5">
+      Widget 5
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Description

The 2nd example shows how to _combine_ media and container queries to create a dashboard. 💯

Traditionally, dashboard widgets are difficult to design and create, since users may expect to be able to customize the dashboard. If we leverage container queries, I think we will have an easier time meeting the wants of designers, developers, and users.

Because creating a dashboard with semi-realistic look will take time, I will make a PR for each widget when it is completed.


## Screenshots

`DEVICE='w1-h3'`

<img width="1680" alt="dashboard_w1_h3" src="https://user-images.githubusercontent.com/16869656/82520409-b13f6200-9ae9-11ea-9dae-8f7b6840bd4b.png">

`DEVICE='w2-h3'`

<img width="1680" alt="dashboard_w2_h3" src="https://user-images.githubusercontent.com/16869656/82520411-b43a5280-9ae9-11ea-9a3d-e9eb828b15f2.png">

`DEVICE='w3-h3'`

<img width="1680" alt="dashboard_w3_h3" src="https://user-images.githubusercontent.com/16869656/82520413-b56b7f80-9ae9-11ea-99a4-932498b2d7cf.png">