### PR TITLE
Replaced Unicode characters with SVG icons

### DIFF
--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -28,7 +28,7 @@ module('Acceptance | dashboard', function(hooks) {
       .exists('We see the captions.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Music Format"]')
-      .hasText('■ 8 - Track', 'We see the music format in correct format.');
+      .hasText('8 - Track', 'We see the music format in correct format.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
       .hasText('Annual revenue: $2.27 billion', 'We see the annual revenue in correct format.');
@@ -66,7 +66,7 @@ module('Acceptance | dashboard', function(hooks) {
       .exists('We see the captions.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Music Format"]')
-      .hasText('■ 8 - Track', 'We see the music format in correct format.');
+      .hasText('8 - Track', 'We see the music format in correct format.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
       .hasText('Annual revenue: $2.27 billion', 'We see the annual revenue in correct format.');
@@ -78,7 +78,7 @@ module('Acceptance | dashboard', function(hooks) {
       .doesNotExist('We don\'t see the previous button.');
 
     assert.dom('[data-test-widget="2"] [data-test-button="Next"]')
-      .hasText('▶', 'We see the next button in correct format.');
+      .hasNoText('We see the next button in correct format.');
 
 
     await takeSnapshot(assert);
@@ -104,7 +104,7 @@ module('Acceptance | dashboard', function(hooks) {
       .exists('We see the captions.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Music Format"]')
-      .hasText('■ 8 - Track', 'We see the music format in correct format.');
+      .hasText('8 - Track', 'We see the music format in correct format.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
       .hasText('Annual revenue: $2.27 billion', 'We see the annual revenue in correct format.');
@@ -116,7 +116,7 @@ module('Acceptance | dashboard', function(hooks) {
       .doesNotExist('We don\'t see the previous button.');
 
     assert.dom('[data-test-widget="2"] [data-test-button="Next"]')
-      .hasText('▶', 'We see the next button in correct format.');
+      .hasNoText('We see the next button in correct format.');
 
 
     await takeSnapshot(assert);
@@ -142,7 +142,7 @@ module('Acceptance | dashboard', function(hooks) {
       .exists('We see the captions.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Music Format"]')
-      .hasText('■ 8 - Track', 'We see the music format in correct format.');
+      .hasText('8 - Track', 'We see the music format in correct format.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
       .hasText('Annual revenue: $2.27 billion', 'We see the annual revenue in correct format.');
@@ -180,7 +180,7 @@ module('Acceptance | dashboard', function(hooks) {
       .exists('We see the captions.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Music Format"]')
-      .hasText('■ 8 - Track', 'We see the music format in correct format.');
+      .hasText('8 - Track', 'We see the music format in correct format.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
       .hasText('Annual revenue: $2.27 billion', 'We see the annual revenue in correct format.');
@@ -192,7 +192,7 @@ module('Acceptance | dashboard', function(hooks) {
       .doesNotExist('We don\'t see the previous button.');
 
     assert.dom('[data-test-widget="2"] [data-test-button="Next"]')
-      .hasText('▶', 'We see the next button in correct format.');
+      .hasNoText('We see the next button in correct format.');
 
 
     await takeSnapshot(assert);
@@ -218,7 +218,7 @@ module('Acceptance | dashboard', function(hooks) {
       .exists('We see the captions.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Music Format"]')
-      .hasText('■ 8 - Track', 'We see the music format in correct format.');
+      .hasText('8 - Track', 'We see the music format in correct format.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
       .hasText('Annual revenue: $2.27 billion', 'We see the annual revenue in correct format.');
@@ -230,7 +230,7 @@ module('Acceptance | dashboard', function(hooks) {
       .doesNotExist('We don\'t see the previous button.');
 
     assert.dom('[data-test-widget="2"] [data-test-button="Next"]')
-      .hasText('▶', 'We see the next button in correct format.');
+      .hasNoText('We see the next button in correct format.');
 
 
     await takeSnapshot(assert);
@@ -256,7 +256,7 @@ module('Acceptance | dashboard', function(hooks) {
       .exists('We see the captions.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Music Format"]')
-      .hasText('■ 8 - Track', 'We see the music format in correct format.');
+      .hasText('8 - Track', 'We see the music format in correct format.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
       .hasText('Annual revenue: $2.27 billion', 'We see the annual revenue in correct format.');
@@ -294,7 +294,7 @@ module('Acceptance | dashboard', function(hooks) {
       .exists('We see the captions.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Music Format"]')
-      .hasText('■ 8 - Track', 'We see the music format in correct format.');
+      .hasText('8 - Track', 'We see the music format in correct format.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
       .hasText('Annual revenue: $2.27 billion', 'We see the annual revenue in correct format.');
@@ -306,7 +306,7 @@ module('Acceptance | dashboard', function(hooks) {
       .doesNotExist('We don\'t see the previous button.');
 
     assert.dom('[data-test-widget="2"] [data-test-button="Next"]')
-      .hasText('▶', 'We see the next button in correct format.');
+      .hasNoText('We see the next button in correct format.');
 
 
     await takeSnapshot(assert);
@@ -332,7 +332,7 @@ module('Acceptance | dashboard', function(hooks) {
       .exists('We see the captions.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Music Format"]')
-      .hasText('■ 8 - Track', 'We see the music format in correct format.');
+      .hasText('8 - Track', 'We see the music format in correct format.');
 
     assert.dom('[data-test-widget="2"] [data-test-field="Annual Revenue"]')
       .hasText('Annual revenue: $2.27 billion', 'We see the annual revenue in correct format.');
@@ -344,7 +344,7 @@ module('Acceptance | dashboard', function(hooks) {
       .doesNotExist('We don\'t see the previous button.');
 
     assert.dom('[data-test-widget="2"] [data-test-button="Next"]')
-      .hasText('▶', 'We see the next button in correct format.');
+      .hasNoText('We see the next button in correct format.');
 
 
     await takeSnapshot(assert);

--- a/tests/dummy/app/components/widgets/widget-2/captions/index.css
+++ b/tests/dummy/app/components/widgets/widget-2/captions/index.css
@@ -28,16 +28,22 @@
 .music-format {
   color: rgba(247, 252, 251, 0.9);
   font-size: 1rem;
+  display: flex;
   grid-area: music-format;
   margin-bottom: 0.5rem;
   word-break: break-word;
 }
 
 .marker {
+  align-items: center;
   background-color: rgba(247, 252, 251, 0.9);
   border-radius: 0.5rem;
-  margin-right: 0.15rem;
-  padding: 0 0.125rem;
+  display: flex;
+  height: 1em;
+  justify-content: center;
+  margin-right: 0.25rem;
+  padding: 0.125rem;
+  width: 1rem;
 }
 
 .annual-revenue {
@@ -65,6 +71,11 @@
 
 .previous-button {
   grid-area: previous-button;
+}
+
+.icon-arrow-back,
+.icon-arrow-forward {
+  fill: rgba(247, 252, 251, 0.9);
 }
 
 .next-button {

--- a/tests/dummy/app/components/widgets/widget-2/captions/index.hbs
+++ b/tests/dummy/app/components/widgets/widget-2/captions/index.hbs
@@ -22,7 +22,10 @@
             local-class="marker"
             style={{this.styleForMarker}}
           >
-            {{~"■"~}}
+            <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path d="M6 6h12v12H6z"></path>
+            </svg>
           </span>
           {{!-- template-lint-enable no-inline-styles style-concatenation --}}
 
@@ -62,7 +65,16 @@
           type="button"
           {{on "click" (fn this.showNextSummary -1)}}
         >
-          {{if CQ.features.tall "Previous" "◀"}}
+          {{#if CQ.features.tall}}
+            Previous
+
+          {{else}}
+            <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" local-class="icon-arrow-back">
+              <path d="M11.67 3.87L9.9 2.1 0 12l9.9 9.9 1.77-1.77L3.54 12z" transform="translate(6,0)"></path>
+              <path d="M0 0h24v24H0z" fill="none"></path>
+            </svg>
+
+          {{/if}}
         </button>
       {{/if}}
 
@@ -74,7 +86,16 @@
           type="button"
           {{on "click" (fn this.showNextSummary 1)}}
         >
-          {{if CQ.features.tall "Next" "▶"}}
+          {{#if CQ.features.tall}}
+            Next
+
+          {{else}}
+            <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" local-class="icon-arrow-forward">
+              <path d="M5.88 4.12L13.76 12l-7.88 7.88L8 22l10-10L8 2z"></path>
+              <path d="M0 0h24v24H0z" fill="none"></path>
+            </svg>
+
+          {{/if}}
         </button>
       {{/if}}
     {{/if}}

--- a/tests/dummy/app/components/widgets/widget-2/captions/index.js
+++ b/tests/dummy/app/components/widgets/widget-2/captions/index.js
@@ -12,7 +12,7 @@ export default class WidgetsWidget2CaptionsComponent extends Component {
       return htmlSafe('');
     }
 
-    return htmlSafe(`color: ${this.summary.markerColor};`);
+    return htmlSafe(`fill: ${this.summary.markerColor};`);
   }
 
   get summaries() {


### PR DESCRIPTION
## Description

After merging #12, I noticed that Unicode characters can render differently in a desktop browser, mobile browser, and Percy snapshots. For consistency, let's render SVG icons instead.


## Notes

The hardcoded definitions came from Material icons and were rendered using `ember-svg-jar`. There are only 4 icons in the demo app so far, so I don't think installing `ember-svg-jar` is necessary at the moment.