### PR TITLE
Allowed yielding dimensions from <ContainerQuery> component

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@ It also accepts these arguments:
 |--|:--:|--|--|
 | @features | Yes<sup>2</sup> | Container query definitions | POJO |
 | @dataAttributePrefix | No | Prefix for data attributes | string |
-| @debounce | No | Debounce time (ms) for resize | number ≥ 0 |
+| @debounce | No | Debounce time for resize (ms) | number ≥ 0 |
 
-The component returns two values that you can consume:
+The component returns a few values that you can consume:
 
-| Name | Yielded | Description |
-|--|:--:|--|
-| features | Yes | Container query results |
-| data-container-query-_{featureName}_ | No | Data attributes for CSS selector |
+| Name | Yielded | Description | Type |
+|--|:--:|--|--|
+| features | Yes | Container query results | POJO |
+| dimensions | Yes | Container dimensions | POJO |
+| data-container-query-_{featureName}_ | No | Data attributes for CSS selector | HTML data attribute |
 
 <sup>1. Do refrain from overusing splattributes (e.g. pass a `{{did-insert}}` modifier to fetch data), since the component's API may change and cause unexpected results. Practice separation of concerns when possible. For example, data fetching can be handled by another element or [`@use` decorator](https://github.com/emberjs/rfcs/blob/use-and-resources/text/0567-use-and-resources.md).</sup>
 
@@ -60,8 +61,8 @@ All helpers accept these arguments:
 
 | Name | Required | Description | Type |
 |--|:--:|--|--|
-| min | Yes<sup>1,2</sup> | Lower bound for feature | number ≥ 0 |
-| max | Yes<sup>1,2</sup> | Upper bound for feature | number ≥ 0 |
+| min | Yes<sup>1</sup> | Lower bound for feature<sup>2</sup> | number ≥ 0 |
+| max | Yes<sup>1</sup> | Upper bound for feature<sup>2</sup> | number ≥ 0 |
 
 <sup>1. The helpers use default values of `min = 0` and `max = Infinity`, and assume the inequalities `min ≤ x < max`. In practice, you will always want to set `min` or `max` (or both).</sup>
 

--- a/addon/components/container-query.hbs
+++ b/addon/components/container-query.hbs
@@ -7,5 +7,10 @@
 >
   {{yield (hash
     features=this.queryResults
+    dimensions=(hash
+      aspectRatio=this.aspectRatio
+      height=this.height
+      width=this.width
+    )
   )}}
 </div>

--- a/addon/components/container-query.js
+++ b/addon/components/container-query.js
@@ -4,6 +4,9 @@ import { tracked } from '@glimmer/tracking';
 
 export default class ContainerQueryComponent extends Component {
   @tracked queryResults = {};
+  @tracked aspectRatio;
+  @tracked height;
+  @tracked width;
 
   get features() {
     return this.args.features ?? {};

--- a/tests/dummy/app/styles/dashboard.css
+++ b/tests/dummy/app/styles/dashboard.css
@@ -17,6 +17,7 @@
     "widget-5";
   grid-template-columns: 1fr;
   grid-template-rows: repeat(4, minmax(12rem, 75%)) 5rem;
+  margin-bottom: 1.5rem;
 }
 
 .widget-1, .widget-2, .widget-3, .widget-4, .widget-5 {
@@ -55,6 +56,7 @@
   @media (min-height: 40rem) {
     .widgets {
       grid-template-rows: repeat(4, 75%) 5rem;
+      margin-bottom: 0;
       overflow-y: auto;
     }
   }
@@ -79,6 +81,7 @@
 
     .widgets {
       grid-template-rows: 3fr 1fr 2fr 5rem;
+      margin-bottom: 0;
     }
   }
 }
@@ -101,6 +104,7 @@
 
     .widgets {
       grid-template-rows: 4fr 1fr 10rem;
+      margin-bottom: 0;
     }
   }
 }

--- a/tests/integration/components/container-query-test.js
+++ b/tests/integration/components/container-query-test.js
@@ -1,4 +1,4 @@
-import { render } from '@ember/test-helpers';
+import { find, render } from '@ember/test-helpers';
 import resizeWindow from 'dummy/tests/helpers/resize-window';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
@@ -22,10 +22,39 @@ module('Integration | Component | container-query', function(hooks) {
         }
       }
     };
+
+    assert.areDimensionsCorrect = (expectedWidth, expectedHeight) => {
+      assert.dom('[data-test-width-height]')
+        .hasText(
+          `${expectedWidth} x ${expectedHeight}`,
+          'Width and height are correct.'
+        );
+
+      const aspectRatio = Number(find('[data-test-aspect-ratio]').textContent.trim());
+      const expectedAspectRatio = expectedWidth / expectedHeight;
+      const tolerance = 0.001;
+
+      if (expectedAspectRatio === Infinity) {
+        assert.strictEqual(
+          aspectRatio === expectedAspectRatio,
+          true,
+          'Aspect ratio is correct.'
+        );
+
+      } else {
+        assert.strictEqual(
+          Math.abs(aspectRatio - expectedAspectRatio) / Math.abs(expectedAspectRatio) < tolerance,
+          true,
+          'Aspect ratio is correct.'
+        );
+
+      }
+    };
   });
 
   hooks.afterEach(function(assert) {
     delete assert.areFeaturesCorrect;
+    delete assert.areDimensionsCorrect;
   });
 
 
@@ -46,6 +75,9 @@ module('Integration | Component | container-query', function(hooks) {
             <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
             <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
             <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
           </ContainerQuery>
         </div>
       `);
@@ -60,6 +92,8 @@ module('Integration | Component | container-query', function(hooks) {
         'ratio-type-B': undefined,
         'ratio-type-C': undefined
       });
+
+      assert.areDimensionsCorrect(500, 800);
     });
 
 
@@ -82,6 +116,9 @@ module('Integration | Component | container-query', function(hooks) {
             <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
             <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
             <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
           </ContainerQuery>
         </div>
       `);
@@ -97,6 +134,8 @@ module('Integration | Component | container-query', function(hooks) {
         'ratio-type-C': undefined
       });
 
+      assert.areDimensionsCorrect(250, 500);
+
 
       await resizeWindow(500, 300);
 
@@ -110,6 +149,8 @@ module('Integration | Component | container-query', function(hooks) {
         'ratio-type-B': undefined,
         'ratio-type-C': undefined
       });
+
+      assert.areDimensionsCorrect(500, 300);
 
 
       await resizeWindow(800, 400);
@@ -125,6 +166,8 @@ module('Integration | Component | container-query', function(hooks) {
         'ratio-type-C': undefined
       });
 
+      assert.areDimensionsCorrect(800, 400);
+
 
       await resizeWindow(1000, 600);
 
@@ -138,6 +181,8 @@ module('Integration | Component | container-query', function(hooks) {
         'ratio-type-B': undefined,
         'ratio-type-C': undefined
       });
+
+      assert.areDimensionsCorrect(1000, 600);
     });
   });
 
@@ -169,6 +214,9 @@ module('Integration | Component | container-query', function(hooks) {
             <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
             <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
             <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
           </ContainerQuery>
         </div>
       `);
@@ -183,6 +231,8 @@ module('Integration | Component | container-query', function(hooks) {
         'ratio-type-B': true,
         'ratio-type-C': false
       });
+
+      assert.areDimensionsCorrect(500, 800);
     });
 
 
@@ -215,6 +265,9 @@ module('Integration | Component | container-query', function(hooks) {
             <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
             <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
             <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
           </ContainerQuery>
         </div>
       `);
@@ -230,6 +283,8 @@ module('Integration | Component | container-query', function(hooks) {
         'ratio-type-C': false
       });
 
+      assert.areDimensionsCorrect(250, 500);
+
 
       await resizeWindow(500, 300);
 
@@ -243,6 +298,8 @@ module('Integration | Component | container-query', function(hooks) {
         'ratio-type-B': false,
         'ratio-type-C': true
       });
+
+      assert.areDimensionsCorrect(500, 300);
 
 
       await resizeWindow(800, 400);
@@ -258,6 +315,8 @@ module('Integration | Component | container-query', function(hooks) {
         'ratio-type-C': false
       });
 
+      assert.areDimensionsCorrect(800, 400);
+
 
       await resizeWindow(1000, 600);
 
@@ -271,6 +330,8 @@ module('Integration | Component | container-query', function(hooks) {
         'ratio-type-B': false,
         'ratio-type-C': true
       });
+
+      assert.areDimensionsCorrect(1000, 600);
     });
   });
 
@@ -305,6 +366,9 @@ module('Integration | Component | container-query', function(hooks) {
             <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
             <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
             <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
           </ContainerQuery>
         </div>
       `);
@@ -392,6 +456,9 @@ module('Integration | Component | container-query', function(hooks) {
             <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
             <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
             <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
           </ContainerQuery>
         </div>
       `);
@@ -486,6 +553,9 @@ module('Integration | Component | container-query', function(hooks) {
             <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
             <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
             <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
           </ContainerQuery>
         </div>
       `);


### PR DESCRIPTION
## Description

I was studying [responsive images](https://developer.mozilla.org/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images) for the next Dashboard widget. In my initial attempt, I found that, when the consuming component doesn't know the container's dimensions, it is difficult to create a good recommendation system.

I had removed yielding of `this.height` and `this.width` in #3. Now, I wonder if there may be more applications that I hadn't thought of, for which users of this addon do need to know the container's _exact dimensions_. It'd be nice if they didn't have to install and add `{{did-insert}}` and `{{did-resize}}` modifiers.

Let's try yielding `dimensions` again. Doing so also helps me test the addon further. ✨