### PR TITLE
Disallowed fingerprinting images for demo app

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,12 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
+    fingerprint: {
+      exclude: [
+        'images/'
+      ],
+      prepend: 'https://ember-container-query.herokuapp.com/'
+    }
   });
 
   /*


### PR DESCRIPTION
## Description

When I visited the [production site](https://ember-container-query.herokuapp.com/dashboard), I noticed that the concert venue image wasn't loaded. Not sure what is the cause just yet.

In this PR, I'm going to try disallowing fingerprinting images and prepending the domain.


## References

https://cli.emberjs.com/release/advanced-use/asset-compilation/#fingerprintingandcdnurls


## Screenshots

Before:

<img width="1680" alt="" src="https://user-images.githubusercontent.com/16869656/82769125-c02f5880-9df8-11ea-9328-ca72884bb9e1.png">