### PR TITLE
Updated CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    # Run the workflow every Monday at 7 am CST
+    - cron: '0 11 * * MON'
 
 env:
   NODE_VERSION: 12.16
@@ -123,6 +126,12 @@ jobs:
           - 'ember-lts-3.16'
           - 'ember-release'
           - 'ember-beta'
+        width:
+          - 'w1'
+          - 'w2'
+          - 'w3'
+        height:
+          - 'h3'
     timeout-minutes: 10
     steps:
       - name: Check out a copy of the repo
@@ -159,5 +168,6 @@ jobs:
           steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
           steps.cache-node-modules.outputs.cache-hit != 'true'
 
+      # Test compatibility without Percy
       - name: Test
-        run: yarn test:ember-compatibility ${{ matrix.scenario }}
+        run: yarn test:ember-compatibility ${{ matrix.scenario }} --- yarn test:ember:${{ matrix.width }}-${{ matrix.height }}


### PR DESCRIPTION
## Description

I forgot to add responsive testing to the compatible versions (1 latest LTS, release, and beta).

If I allow the full test matrix of width and height, the workflow will run 37 jobs.

```
1 lint + 9 test-addon + 27 test-compatibility = 37
```

Because the `actions/cache@v1` library can sometimes fail to retrieve the cache, the more jobs there are running, the more likely that the CI can be a detriment to active development.

As a middle ground, let's check just `w1-h3`, `w2-h3`, and `w3-h3` for `test-compatibility`. These represent a mobile, tablet, and desktop of reasonable size. The number of jobs is reduced to:

```
1 lint + 9 test-addon + 9 test-compatibility = 19
```

The number 19 also happens to be less than 20, the [number of concurrent jobs that GitHub Actions allows](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#usage-limits) under the free plan.