### PR TITLE
Created Dashboard example (Part 5 of 5)

### DIFF
--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -71,6 +71,11 @@ module('Acceptance | dashboard', function(hooks) {
       .hasClass(/minimal-layout/, 'The memo actions uses the minimal layout.');
 
 
+    // Widget 5
+    assert.dom('[data-test-widget="5"] [data-test-call-to-action]')
+      .hasText('ember-container-query', 'We see the correct call to action.');
+
+
     await takeSnapshot(assert);
   });
 
@@ -135,6 +140,11 @@ module('Acceptance | dashboard', function(hooks) {
 
     assert.dom('[data-test-widget="4"] [data-test-memo-actions]')
       .hasClass(/minimal-layout/, 'The memo actions uses the minimal layout.');
+
+
+    // Widget 5
+    assert.dom('[data-test-widget="5"] [data-test-call-to-action]')
+      .hasText('ember-container-query', 'We see the correct call to action.');
 
 
     await takeSnapshot(assert);
@@ -203,6 +213,11 @@ module('Acceptance | dashboard', function(hooks) {
       .doesNotHaveClass(/minimal-layout/, 'The memo actions doesn\'t use the minimal layout.');
 
 
+    // Widget 5
+    assert.dom('[data-test-widget="5"] [data-test-call-to-action]')
+      .hasText('What will you create with ember-container-query ?', 'We see the correct call to action.');
+
+
     await takeSnapshot(assert);
   });
 
@@ -267,6 +282,11 @@ module('Acceptance | dashboard', function(hooks) {
 
     assert.dom('[data-test-widget="4"] [data-test-memo-actions]')
       .hasClass(/minimal-layout/, 'The memo actions uses the minimal layout.');
+
+
+    // Widget 5
+    assert.dom('[data-test-widget="5"] [data-test-call-to-action]')
+      .hasText('ember-container-query', 'We see the correct call to action.');
 
 
     await takeSnapshot(assert);
@@ -335,6 +355,11 @@ module('Acceptance | dashboard', function(hooks) {
       .hasClass(/minimal-layout/, 'The memo actions uses the minimal layout.');
 
 
+    // Widget 5
+    assert.dom('[data-test-widget="5"] [data-test-call-to-action]')
+      .hasText('ember-container-query', 'We see the correct call to action.');
+
+
     await takeSnapshot(assert);
   });
 
@@ -399,6 +424,11 @@ module('Acceptance | dashboard', function(hooks) {
 
     assert.dom('[data-test-widget="4"] [data-test-memo-actions]')
       .doesNotHaveClass(/minimal-layout/, 'The memo actions doesn\'t use the minimal layout.');
+
+
+    // Widget 5
+    assert.dom('[data-test-widget="5"] [data-test-call-to-action]')
+      .hasText('What will you create with ember-container-query ?', 'We see the correct call to action.');
 
 
     await takeSnapshot(assert);
@@ -467,6 +497,11 @@ module('Acceptance | dashboard', function(hooks) {
       .doesNotHaveClass(/minimal-layout/, 'The memo actions doesn\'t use the minimal layout.');
 
 
+    // Widget 5
+    assert.dom('[data-test-widget="5"] [data-test-call-to-action]')
+      .hasText('ember-container-query', 'We see the correct call to action.');
+
+
     await takeSnapshot(assert);
   });
 
@@ -533,6 +568,11 @@ module('Acceptance | dashboard', function(hooks) {
       .hasClass(/minimal-layout/, 'The memo actions uses the minimal layout.');
 
 
+    // Widget 5
+    assert.dom('[data-test-widget="5"] [data-test-call-to-action]')
+      .hasText('ember-container-query', 'We see the correct call to action.');
+
+
     await takeSnapshot(assert);
   });
 
@@ -597,6 +637,11 @@ module('Acceptance | dashboard', function(hooks) {
 
     assert.dom('[data-test-widget="4"] [data-test-memo-actions]')
       .doesNotHaveClass(/minimal-layout/, 'The memo actions doesn\'t use the minimal layout.');
+
+
+    // Widget 5
+    assert.dom('[data-test-widget="5"] [data-test-call-to-action]')
+      .hasText('What will you create with ember-container-query ?', 'We see the correct call to action.');
 
 
     await takeSnapshot(assert);

--- a/tests/dummy/app/components/widgets/widget-5/index.css
+++ b/tests/dummy/app/components/widgets/widget-5/index.css
@@ -1,0 +1,41 @@
+.container {
+  height: 100%;
+  overflow: hidden;
+}
+
+.call-to-action {
+  height: 100%;
+  width: 100%;
+
+  font-size: 0.8rem;
+  line-height: 1.25;
+
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.call-to-action p {
+  margin: 0;
+}
+
+.call-to-action .highlight {
+  font-family: monospace;
+}
+
+.call-to-action a {
+  display: block;
+  height: calc(100% - 2 * (0.2rem + 0.0625rem));
+  padding: 0.2rem 0.5rem;
+  width: calc(100% - 2 * (0.5rem + 0.0625rem));
+
+  border: 0.0625rem solid white;
+  text-decoration: none;
+}
+
+
+.container[data-container-query-tall] .call-to-action {
+  font-size: 0.875rem;
+  line-height: 1.75;
+}

--- a/tests/dummy/app/components/widgets/widget-5/index.hbs
+++ b/tests/dummy/app/components/widgets/widget-5/index.hbs
@@ -1,0 +1,30 @@
+<ContainerQuery
+  @features={{hash
+    large=(cq-width min=224)
+    tall=(cq-height min=120)
+  }}
+  local-class="container"
+  as |CQ|
+>
+  {{#let
+    (and CQ.features.large CQ.features.tall)
+    as |showFullText|
+  }}
+    <div
+      data-test-call-to-action
+      local-class="call-to-action"
+    >
+      {{#if showFullText}}
+        <p>What will <em>you</em> create with</p>
+      {{/if}}
+
+      <p local-class="highlight">
+        <a href="https://github.com/ijlee2/ember-container-query" target="_blank" rel="noopener noreferrer">ember-container-query</a>
+      </p>
+
+      {{#if showFullText}}
+        <p>?</p>
+      {{/if}}
+    </div>
+  {{/let}}
+</ContainerQuery>

--- a/tests/dummy/app/templates/dashboard.hbs
+++ b/tests/dummy/app/templates/dashboard.hbs
@@ -20,8 +20,8 @@
       <Widgets::Widget-4 />
     </div>
 
-    <div local-class="widget-5">
-      Widget 5
+    <div data-test-widget="5" local-class="widget-5">
+      <Widgets::Widget-5 />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Description

The final piece to finishing the Dashboard page!  🎉

It only felt appropriate to add a border around the text `ember-container-query`.


## Screenshots

`DEVICE='w1-h3'`

<img width="1680" alt="dashboard_w1_h3" src="https://user-images.githubusercontent.com/16869656/82865640-d1599180-9eec-11ea-8d51-c5e21fbd0d24.png">

`DEVICE='w2-h3'`

<img width="1680" alt="dashboard_w2_h3" src="https://user-images.githubusercontent.com/16869656/82865655-d61e4580-9eec-11ea-9efe-decd20621147.png">

`DEVICE='w3-h3'`

<img width="1680" alt="dashboard_w3_h3" src="https://user-images.githubusercontent.com/16869656/82865667-de768080-9eec-11ea-9615-c2fd3a04452f.png">