### PR TITLE
Applied overflow hidden to the splash image

### DIFF
--- a/tests/dummy/app/components/widgets/widget-3/index.css
+++ b/tests/dummy/app/components/widgets/widget-3/index.css
@@ -17,4 +17,5 @@
   display: flex;
   flex: 1;
   flex-direction: column;
+  overflow: hidden;
 }

--- a/tests/dummy/app/components/widgets/widget-3/tour-schedule/index.css
+++ b/tests/dummy/app/components/widgets/widget-3/tour-schedule/index.css
@@ -15,6 +15,7 @@
   height: 100%;
   grid-area: splash;
   width: 100%;
+  overflow: hidden;
 
   position: relative;
 }


### PR DESCRIPTION
## Description

On Firefox, I noticed that the splash image spills over the container. I didn't see this happen with Chrome and Safari.

To help contributors and myself, I enabled taking Percy snapshots on Firefox in addition to Chrome.


## Screenshots

Before:

<img width="1680" alt="Screen Shot 2020-05-26 at 8 12 47 PM" src="https://user-images.githubusercontent.com/16869656/82965406-a2dfc300-9f8d-11ea-84c0-91bb3ff1d53c.png">

After:

<img width="1680" alt="Screen Shot 2020-05-26 at 8 12 35 PM" src="https://user-images.githubusercontent.com/16869656/82965403-a115ff80-9f8d-11ea-96b4-357a699b494d.png">