### PR TITLE
Fixed overflow issues on Firefox and Safari

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,8 @@ Here are some suggestions to help you start:
 
     I believe, if we can spend a few extra hours to address these issues, we can better maintain this project on the long run.
 
+1. Please check if the demo app looks correct by resizing the window on Chrome and Firefox. Percy snapshots are taken in these browsers so we have good references. Checking on Safari and Edge are optional but recommended.
+
 1. At any point, if you are unsure of something, don't hesitate to reach out!
 
 </details>

--- a/tests/dummy/app/components/widgets/widget-1/index.css
+++ b/tests/dummy/app/components/widgets/widget-1/index.css
@@ -8,6 +8,7 @@
   display: grid;
   grid-gap: 0.6rem;
   flex: 1;
+  overflow: hidden;
 }
 
 .item-1 {

--- a/tests/dummy/app/styles/not-found.css
+++ b/tests/dummy/app/styles/not-found.css
@@ -34,6 +34,7 @@
   border: 0.0625rem solid white;;
   border-radius: 0.1875rem;
   height: calc(4.5rem - 2 * (0.2rem + 0.0625rem));
+  width: calc(100% - 2 * (0.5rem + 0.0625rem));
   padding: 0.2rem 0.5rem;
 
   font-family: monospace;


### PR DESCRIPTION
## Description

On Firefox, the text inside the box doesn't protrude outside when the box gets squished.

<img width="320" alt="404_firefox" src="https://user-images.githubusercontent.com/16869656/83098865-5b326780-a071-11ea-9d29-13fa07dc93a4.gif">

On Safari, the `<Widgets::Widget-1::Item>` component overflowed outside the container.

<img width="280" alt="widget-1_safari" src="https://user-images.githubusercontent.com/16869656/83098970-959c0480-a071-11ea-842f-7a2216fa6c80.png">

In commit 1, I fixed both issues.

In commit 2, I updated `CONTRIBUTING.md` to ask people to check the demo app on Chrome and Firefox before they make a pull request. Percy snapshots are taken on these browsers so we should have some good references.