### PR TITLE
Limited supported setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,10 @@ For more examples, I encourage you to check out the code for my demo app. It is 
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.16 or above
+* Ember.js v3.16 or above (3.12 - 3.15 may work but won't be supported)
 * Ember CLI v2.13 or above
 * Node.js v10 or above
+* Modern browsers (IE 11 may work but won't be supported)
 
 
 Contributing

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,18 +1,12 @@
 'use strict';
 
-const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions'
-];
-
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
-  browsers
+  browsers: [
+    'last 2 Chrome versions',
+    'last 2 Firefox versions',
+    'last 2 Safari versions',
+    // Latest versions of Microsoft Edge are built on top of Chromium.
+    // However, not a significant number of users use the latest yet.
+    'Edge >= 18'
+  ]
 };


### PR DESCRIPTION
## Description

Until I can recruit contributors to help maintain the addon with me, I don't think it's practical for me to support various user and developer environments.

I listed Ember v3.12 as a possible minimum based on `ember-did-resize-modifier`'s compatibility matrix, but didn't test whether the addon works on a 3.12 app (even possibly, earlier versions).

I based the target string for Microsoft Edge based on `ember-file-upload`, an addon that I recently looked at.


## References

- https://github.com/emberjs/ember-render-modifiers#compatibility
- https://github.com/gmurphey/ember-did-resize-modifier#compatibility
- https://github.com/adopted-ember-addons/ember-file-upload/pull/346