### PR TITLE
Updated language for supported setups to be clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Compatibility
 * Ember.js v3.16 or above (3.12 - 3.15 may work but won't be supported)
 * Ember CLI v2.13 or above
 * Node.js v10 or above
-* Modern browsers (IE 11 may work but won't be supported)
+* Modern browsers (IE 11 won't be supported)
 
 
 Contributing


### PR DESCRIPTION
## Description

I don't think we'll want to support IE 11 when it comes to container queries.

I was reading up on the native [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) API. IE 11 doesn't support it, without surprise.


## References

https://caniuse.com/#search=ResizeObserver