### PR TITLE
Restored assertions for responsive images

### DIFF
--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -53,8 +53,8 @@ module('Acceptance | dashboard', function(hooks) {
     assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
       .exists('We see the concert venue image.');
 
-    // assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
-    //   .hasAttribute('src', '/images/widgets/widget-3/venue-wide@2x.jpg', 'We responsively loaded the correct image.');
+    assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
+      .hasAttribute('src', '/images/widgets/widget-3/venue-wide@2x.jpg', 'We responsively loaded the correct image.');
 
 
     // Widget 4
@@ -124,8 +124,8 @@ module('Acceptance | dashboard', function(hooks) {
     assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
       .exists('We see the concert venue image.');
 
-    // assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
-    //   .hasAttribute('src', '/images/widgets/widget-3/venue-extra-wide@2x.jpg', 'We responsively loaded the correct image.');
+    assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
+      .hasAttribute('src', '/images/widgets/widget-3/venue-extra-wide@2x.jpg', 'We responsively loaded the correct image.');
 
 
     // Widget 4
@@ -195,8 +195,8 @@ module('Acceptance | dashboard', function(hooks) {
     assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
       .exists('We see the concert venue image.');
 
-    // assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
-    //   .hasAttribute('src', '/images/widgets/widget-3/venue-extra-wide@2x.jpg', 'We responsively loaded the correct image.');
+    assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
+      .hasAttribute('src', '/images/widgets/widget-3/venue-extra-wide@2x.jpg', 'We responsively loaded the correct image.');
 
 
     // Widget 4
@@ -266,8 +266,8 @@ module('Acceptance | dashboard', function(hooks) {
     assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
       .exists('We see the concert venue image.');
 
-    // assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
-    //   .hasAttribute('src', '/images/widgets/widget-3/venue-wide@2x.jpg', 'We responsively loaded the correct image.');
+    assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
+      .hasAttribute('src', '/images/widgets/widget-3/venue-wide@2x.jpg', 'We responsively loaded the correct image.');
 
 
     // Widget 4
@@ -337,8 +337,8 @@ module('Acceptance | dashboard', function(hooks) {
     assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
       .exists('We see the concert venue image.');
 
-    // assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
-    //   .hasAttribute('src', '/images/widgets/widget-3/venue-extra-wide@2x.jpg', 'We responsively loaded the correct image.');
+    assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
+      .hasAttribute('src', '/images/widgets/widget-3/venue-extra-wide@2x.jpg', 'We responsively loaded the correct image.');
 
 
     // Widget 4
@@ -408,8 +408,8 @@ module('Acceptance | dashboard', function(hooks) {
     assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
       .exists('We see the concert venue image.');
 
-    // assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
-    //   .hasAttribute('src', '/images/widgets/widget-3/venue-extra-wide@2x.jpg', 'We responsively loaded the correct image.');
+    assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
+      .hasAttribute('src', '/images/widgets/widget-3/venue-extra-wide@2x.jpg', 'We responsively loaded the correct image.');
 
 
     // Widget 4
@@ -479,8 +479,8 @@ module('Acceptance | dashboard', function(hooks) {
     assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
       .exists('We see the concert venue image.');
 
-    // assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
-    //   .hasAttribute('src', '/images/widgets/widget-3/venue-square@4x.jpg', 'We responsively loaded the correct image.');
+    assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
+      .hasAttribute('src', '/images/widgets/widget-3/venue-square@4x.jpg', 'We responsively loaded the correct image.');
 
 
     // Widget 4
@@ -550,8 +550,8 @@ module('Acceptance | dashboard', function(hooks) {
     assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
       .exists('We see the concert venue image.');
 
-    // assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
-    //   .hasAttribute('src', '/images/widgets/widget-3/venue-wide@2x.jpg', 'We responsively loaded the correct image.');
+    assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
+      .hasAttribute('src', '/images/widgets/widget-3/venue-wide@2x.jpg', 'We responsively loaded the correct image.');
 
 
     // Widget 4
@@ -621,8 +621,8 @@ module('Acceptance | dashboard', function(hooks) {
     assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
       .exists('We see the concert venue image.');
 
-    // assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
-    //   .hasAttribute('src', '/images/widgets/widget-3/venue-extra-wide@2x.jpg', 'We responsively loaded the correct image.');
+    assert.dom('[data-test-widget="3"] [data-test-image="Concert"]')
+      .hasAttribute('src', '/images/widgets/widget-3/venue-extra-wide@2x.jpg', 'We responsively loaded the correct image.');
 
 
     // Widget 4


### PR DESCRIPTION
## Description

In #16, I had to comment a set of assertions that passed locally but [didn't in CI](https://github.com/ijlee2/ember-container-query/runs/704674464). I wanted to check if these assertions would now pass somehow, and to my pleasant surprise, they did.

A couple of possible explanations:

1\. In #24 (maybe in conjunction with #23 and #28), I fixed overflow issues. In other words, the app layout improved since #16.

2\. In #18, I updated the ranking algorithm to better handle an edge case.