### PR TITLE
Added tests for @debounce

### DIFF
--- a/tests/helpers/resize-window.js
+++ b/tests/helpers/resize-window.js
@@ -2,13 +2,18 @@ import { assert } from '@ember/debug';
 import { later } from '@ember/runloop';
 import { find } from '@ember/test-helpers';
 
-const timeout = milliseconds => {
+// This is a magic number. It is the time (in ms) for things to `settle`
+// after a resize. It is the time that we need to wait before assertions
+// that should pass will always pass.
+const RERENDER_TIME = 100;
+
+
+export function timeout(milliseconds) {
   return new Promise(resolve => {
     later(resolve, milliseconds);
   });
-};
+}
 
-const rerenderTime = 100;
 
 export default async function resizeWindow(width, height) {
   let parentElement = find('[data-test-parent-element]');
@@ -18,8 +23,11 @@ export default async function resizeWindow(width, height) {
     !!parentElement
   );
 
+  // Since <ContainerQuery> has a style of `height: 100%; width: 100%;`,
+  // we can set its parent element's width and height to cause container
+  // queries to be evaluated.
   parentElement.style.width = `${width}px`;
   parentElement.style.height = `${height}px`;
 
-  await timeout(rerenderTime);
+  await timeout(RERENDER_TIME);
 }

--- a/tests/integration/components/container-query-test.js
+++ b/tests/integration/components/container-query-test.js
@@ -1,5 +1,5 @@
 import { find, render } from '@ember/test-helpers';
-import resizeWindow from 'dummy/tests/helpers/resize-window';
+import resizeWindow, { timeout } from 'dummy/tests/helpers/resize-window';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -457,6 +457,130 @@ module('Integration | Component | container-query', function(hooks) {
         .doesNotHaveAttribute('data-cq-ratio-type-A')
         .doesNotHaveAttribute('data-cq-ratio-type-B')
         .hasAttribute('data-cq-ratio-type-C');
+    });
+  });
+
+
+  module('When @debounce is passed', function() {
+    test('Container queries are debounced until the @debounce time passes', async function(assert) {
+      /*
+        Caution:
+
+        There is a dependency between the implementations of this test and
+        the `resizeWindow` test helper. The test helper waits for 100ms to
+        pass so that assertions that should pass will always pass.
+
+        As a result, we can test `@debounce` only when the value is larger
+        than 100.
+      */
+      this.debounce = 250;
+
+      await render(hbs`
+        <div
+          data-test-parent-element
+          style="width: 250px; height: 500px;"
+        >
+          <ContainerQuery
+            @features={{hash
+              small=(cq-width max=300)
+              medium=(cq-width min=300 max=600)
+              large=(cq-width min=600 max=900)
+              short=(cq-height max=500)
+              tall=(cq-height min=500)
+              ratio-type-A=(cq-aspect-ratio min=0.25 max=0.75)
+              ratio-type-B=(cq-aspect-ratio min=0.5 max=1.5)
+              ratio-type-C=(cq-aspect-ratio min=1.25 max=2)
+            }}
+            @debounce={{this.debounce}}
+            as |CQ|
+          >
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
+
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
+
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
+          </ContainerQuery>
+        </div>
+      `);
+
+      assert.areFeaturesCorrect({
+        small: true,
+        medium: false,
+        large: false,
+        short: false,
+        tall: true,
+        'ratio-type-A': true,
+        'ratio-type-B': true,
+        'ratio-type-C': false
+      });
+
+
+      // After a resize, the container query results should remain the
+      // same as before.
+      await resizeWindow(500, 300);
+
+      assert.areFeaturesCorrect({
+        small: true,
+        medium: false,
+        large: false,
+        short: false,
+        tall: true,
+        'ratio-type-A': true,
+        'ratio-type-B': true,
+        'ratio-type-C': false
+      });
+
+
+      await resizeWindow(800, 400);
+
+      assert.areFeaturesCorrect({
+        small: true,
+        medium: false,
+        large: false,
+        short: false,
+        tall: true,
+        'ratio-type-A': true,
+        'ratio-type-B': true,
+        'ratio-type-C': false
+      });
+
+
+      await resizeWindow(1000, 600);
+
+      assert.areFeaturesCorrect({
+        small: true,
+        medium: false,
+        large: false,
+        short: false,
+        tall: true,
+        'ratio-type-A': true,
+        'ratio-type-B': true,
+        'ratio-type-C': false
+      });
+
+
+      // After the debounce time passes, the container query results
+      // will update.
+      await timeout(this.debounce);
+
+      assert.areFeaturesCorrect({
+        small: false,
+        medium: false,
+        large: false,
+        short: false,
+        tall: true,
+        'ratio-type-A': false,
+        'ratio-type-B': false,
+        'ratio-type-C': true
+      });
     });
   });
 


### PR DESCRIPTION
## Description

I didn't write tests for `@debounce` before. Although I use the `{{did-resize}}` modifier's debounce feature directly and [that feature has been tested](https://github.com/gmurphey/ember-did-resize-modifier/blob/master/tests/integration/modifiers/did-resize-test.js#L85-L104), we should still write tests for `@debounce` since it is a public API for this addon.

Should we need to replace the underlying method for listening to element resize, we can use the additional tests for `@debounce` to make the transition with more confidence.