### PR TITLE
Updated keywords and repository url for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,14 @@
   "version": "1.0.1",
   "description": "Container queries using Ember modifiers",
   "keywords": [
-    "ember-addon"
+    "container-queries",
+    "container-query",
+    "element-queries",
+    "element-query",
+    "ember-addon",
+    "ember-octane",
+    "emberjs",
+    "responsive-design"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ijlee2/ember-container-query"
+    "url": "https://github.com/ijlee2/ember-container-query.git"
   },
   "license": "MIT",
   "author": "Isaac J. Lee",


### PR DESCRIPTION
## Description

After I published `ember-container-query` to `npm`, I realized that `npm` creates the list of keywords from `package.json`. As I was writing an addon for the first time, I had kept the default value:

```json
{
  "keywords": [
    "ember-addon"
  ]
}
```

I updated the value to list all keywords that I used for GitHub. I don't think adding hyphens between words matters to `npm`.

```javascript
{
  "keywords": [
    "container-queries",
    "container-query",
    "element-queries",
    "element-query",
    "ember-addon",
    "ember-octane",
    "emberjs",
    "responsive-design"
  ]
}
```

I also updated the repository URL format to match that shown in the `npm` documentation. As far as I could tell, the current URL worked fine, but just in case...


## Screenshots

Before: Only `ember-addon` showed up in the list of keywords.

<img width="360" alt="npm_keywords" src="https://user-images.githubusercontent.com/16869656/83330884-cfc6fb00-a257-11ea-98e7-ba66e7d90a2b.png">

After: TODO


## References

- https://docs.npmjs.com/files/package.json#keywords
- https://docs.npmjs.com/files/package.json#repository