### PR TITLE
Added adoption strategy for developers who support pre-Octane app or IE 11 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI](https://github.com/ijlee2/ember-container-query/workflows/CI/badge.svg)
+[![This project uses GitHub Actions for continuous integration.](https://github.com/ijlee2/ember-container-query/workflows/CI/badge.svg)](https://github.com/ijlee2/ember-container-query/actions?query=workflow%3ACI)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/Isaac/ember-container-query)
 
 ember-container-query

--- a/README.md
+++ b/README.md
@@ -243,10 +243,12 @@ For more examples, I encourage you to check out the code for my demo app. It is 
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.16 or above (3.12 - 3.15 may work but won't be supported)
+* Ember.js v3.16 or above<sup>1</sup> (3.12 - 3.15 may work but won't be supported)
 * Ember CLI v2.13 or above
 * Node.js v10 or above
-* Modern browsers (IE 11 won't be supported)
+* Modern browsers<sup>1</sup> (IE 11 won't be supported)
+
+<sup>1. Until you can adopt Ember Octane and drop support for IE 11, I recommend using [`ember-fill-up`](https://github.com/chadian/ember-fill-up) to do container queries. The APIs are similar so your migration should be smooth. Chad Carbert and I will ensure that the addons are maintained side-by-side for some time.</sup>
 
 
 Contributing


### PR DESCRIPTION
## Description

In Discord, Chad and I talked about maintaining `ember-fill-up` and `ember-container-query` side-by-side for some time, so that we can support more Ember developers who want to make container queries in their app or addon.

I updated the README to explain the adoption strategy.


## Notes

Since our addon APIs are similar, I don't think a detailed migration strategy needs to be added to the README.

If needed, however, we can add a `h2` or `h3`-level section to show an example of migrating code. Take the `<Tracks>` component in the README, for example. We might show:

```javascript
// With ember-fill-up

<FillUp
  @breakpoints={{hash
    small=(fill-up-lt 480)
    medium=(fill-up-between 480 640)
    large=(fill-up-gte 640)
    tall=(fill-up-gte 320 dimension="height")
  }}
  as |F|
>
  {{#if (and F.breakpoints.large F.breakpoints.tall)}}
    <Tracks::Table
      @tracks={{@tracks}}
    />

  {{else}}
    <Tracks::List
      @numColumns={{
        if F.breakpoints.small 1
        (if F.breakpoints.medium 2 3)
      }}
      @tracks={{@tracks}}
    />

  {{/if}}
</FillUp>
```

```javascript
// With ember-container-query

<ContainerQuery
  @features={{hash
    small=(cq-width max=480)
    medium=(cq-width min=480 max=640)
    large=(cq-width min=640)
    tall=(cq-height min=320)
  }}
  as |CQ|
>
  {{#if (and CQ.features.large CQ.features.tall)}}
    <Tracks::Table
      @tracks={{@tracks}}
    />

  {{else}}
    <Tracks::List
      @numColumns={{
        if CQ.features.small 1
        (if CQ.features.medium 2 3)
      }}
      @tracks={{@tracks}}
    />

  {{/if}}
</ContainerQuery>
```