### PR TITLE
Allowed passing empty string for @dataAttributePrefix

### DIFF
--- a/addon/components/container-query.js
+++ b/addon/components/container-query.js
@@ -49,7 +49,15 @@ export default class ContainerQueryComponent extends Component {
     const prefix = this.dataAttributePrefix;
 
     for (const [featureName, meetsFeature] of Object.entries(this.queryResults)) {
-      const attributeName = `data-${prefix}-${featureName}`;
+      let attributeName;
+
+      if (prefix) {
+        attributeName = `data-${prefix}-${featureName}`;
+
+      } else {
+        attributeName = `data-${featureName}`;
+
+      }
 
       if (meetsFeature) {
         element.setAttribute(attributeName, '');

--- a/tests/integration/components/container-query/dataAttributePrefix-test.js
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.js
@@ -108,7 +108,106 @@ module('Integration | Component | container-query', function(hooks) {
   });
 
 
-  module('When @dataAttributePrefix is passed', function(hooks) {
+  module('When @dataAttributePrefix is passed (empty string)', function(hooks) {
+    hooks.beforeEach(async function() {
+      await render(hbs`
+        <div
+          data-test-parent-element
+          style="width: 250px; height: 500px;"
+        >
+          <ContainerQuery
+            @features={{hash
+              small=(cq-width max=300)
+              medium=(cq-width min=300 max=600)
+              large=(cq-width min=600 max=900)
+              short=(cq-height max=500)
+              tall=(cq-height min=500)
+              ratio-type-A=(cq-aspect-ratio min=0.25 max=0.75)
+              ratio-type-B=(cq-aspect-ratio min=0.5 max=1.5)
+              ratio-type-C=(cq-aspect-ratio min=1.25 max=2)
+            }}
+            @dataAttributePrefix=""
+            as |CQ|
+          >
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
+
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
+
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
+          </ContainerQuery>
+        </div>
+      `);
+    });
+
+
+    test('The component creates data attributes when it is rendered', async function(assert) {
+      assert.areDataAttributesCorrect({
+        'data-small': '',
+        'data-medium': undefined,
+        'data-large': undefined,
+        'data-short': undefined,
+        'data-tall': '',
+        'data-ratio-type-A': '',
+        'data-ratio-type-B': '',
+        'data-ratio-type-C': undefined
+      });
+    });
+
+
+    test('The component updates data attributes when it is resized', async function(assert) {
+      await resizeContainer(500, 300);
+
+      assert.areDataAttributesCorrect({
+        'data-small': undefined,
+        'data-medium': '',
+        'data-large': undefined,
+        'data-short': '',
+        'data-tall': undefined,
+        'data-ratio-type-A': undefined,
+        'data-ratio-type-B': undefined,
+        'data-ratio-type-C': ''
+      });
+
+
+      await resizeContainer(800, 400);
+
+      assert.areDataAttributesCorrect({
+        'data-small': undefined,
+        'data-medium': undefined,
+        'data-large': '',
+        'data-short': '',
+        'data-tall': undefined,
+        'data-ratio-type-A': undefined,
+        'data-ratio-type-B': undefined,
+        'data-ratio-type-C': undefined
+      });
+
+
+      await resizeContainer(1000, 600);
+
+      assert.areDataAttributesCorrect({
+        'data-small': undefined,
+        'data-medium': undefined,
+        'data-large': undefined,
+        'data-short': undefined,
+        'data-tall': '',
+        'data-ratio-type-A': undefined,
+        'data-ratio-type-B': undefined,
+        'data-ratio-type-C': ''
+      });
+    });
+  });
+
+
+  module('When @dataAttributePrefix is passed (non-empty string)', function(hooks) {
     hooks.beforeEach(async function() {
       await render(hbs`
         <div


### PR DESCRIPTION
## Description

I forgot to test an edge case for `@dataAttributePrefix`. When a user passes an empty string (meaning they don't want a prefix for brevity), the data attributes should be in the form of `data-tall`, instead of `data--tall`.