### PR TITLE
Switch out nullish operator for ternary to allow loading in fastboot

### DIFF
--- a/addon/components/container-query.js
+++ b/addon/components/container-query.js
@@ -9,15 +9,15 @@ export default class ContainerQueryComponent extends Component {
   @tracked width;
 
   get features() {
-    return this.args.features ?? {};
+    return this.args.features ? this.args.features : {};
   }
 
   get dataAttributePrefix() {
-    return this.args.dataAttributePrefix ?? 'container-query';
+    return this.args.dataAttributePrefix ? this.args.dataAttributePrefix : 'container-query';
   }
 
   get debounce() {
-    return this.args.debounce ?? 0;
+    return this.args.debounce ? this.args.debounce : 0;
   }
 
   constructor() {

--- a/tests/dummy/app/components/tracks/list/index.js
+++ b/tests/dummy/app/components/tracks/list/index.js
@@ -3,7 +3,7 @@ import Component from '@glimmer/component';
 
 export default class TracksListComponent extends Component {
   get numColumns() {
-    return this.args.numColumns ?? 1;
+    return this.args.numColumns ? this.args.numColumns : 1;
   }
 
   get numRows() {
@@ -11,7 +11,7 @@ export default class TracksListComponent extends Component {
   }
 
   get tracks() {
-    return this.args.tracks ?? [];
+    return this.args.tracks ? this.args.tracks : [];
   }
 
   @action updateCssForRows(element) {

--- a/tests/dummy/app/components/widgets/widget-2/captions/index.js
+++ b/tests/dummy/app/components/widgets/widget-2/captions/index.js
@@ -16,7 +16,7 @@ export default class WidgetsWidget2CaptionsComponent extends Component {
   }
 
   get summaries() {
-    return this.args.summaries ?? [];
+    return this.args.summaries ? this.args.summaries : [];
   }
 
   get canShowPreviousButton() {

--- a/tests/dummy/app/components/widgets/widget-2/stacked-chart/index.js
+++ b/tests/dummy/app/components/widgets/widget-2/stacked-chart/index.js
@@ -27,7 +27,7 @@ export default class WidgetsWidget2StackedChartComponent extends Component {
   }
 
   get data() {
-    return this.args.data ?? [];
+    return this.args.data ? this.args.data : [];
   }
 
   get margin() {


### PR DESCRIPTION
I love the nullish operator, but unfortunately fastboot errors upon startup with it in there. This PR switches it for the ternary operator.

P.S. Nice addon!