### PR TITLE
Updated CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
 
   test-addon:
     name: Test addon
+    needs: [build-ember-app]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -132,10 +133,16 @@ jobs:
         run: yarn install --frozen-lockfile
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
+      - name: Download built Ember app
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+
       - name: Test
         uses: percy/exec-action@v0.3.0
         with:
-          custom-command: yarn test:ember:${{ matrix.width }}-${{ matrix.height }}
+          custom-command: yarn test:ember:${{ matrix.width }}-${{ matrix.height }} --path=dist
         env:
           PERCY_PARALLEL_NONCE: ${{ env.PERCY_PARALLEL_NONCE }}
           PERCY_PARALLEL_TOTAL: ${{ env.PERCY_PARALLEL_TOTAL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 11 * * MON'
 
 env:
-  NODE_VERSION: 12.16
+  NODE_VERSION: 12.18
   PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_number }}
   PERCY_PARALLEL_TOTAL: 9
 
@@ -18,7 +18,7 @@ jobs:
   lint:
     name: Lint files and dependencies
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 7
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
           - 'h1'
           - 'h2'
           - 'h3'
-    timeout-minutes: 15
+    timeout-minutes: 7
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2
@@ -116,7 +116,7 @@ jobs:
           - 'w3'
         height:
           - 'h3'
-    timeout-minutes: 15
+    timeout-minutes: 7
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,47 @@ env:
   PERCY_PARALLEL_TOTAL: 9
 
 jobs:
+  build-ember-app:
+    name: Build Ember app
+    runs-on: ubuntu-latest
+    timeout-minutes: 7
+    steps:
+      - name: Check out a copy of the repo
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Get Yarn cache path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache Yarn cache and node_modules
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-${{ env.NODE_VERSION }}-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+
+      - name: Build Ember app
+        run: yarn ember build --environment=test
+
+      - name: Upload built Ember app
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+
   lint:
     name: Lint files and dependencies
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

From [Donald's comment](https://dev.to/dknutsen/comment/1431k), I learned that we can pre-build the demo app for testing. As a result, 9 jobs grouped under `test-addon` now don't need to build the app.

I also updated the Node version to `12.18` (latest LTS at the time of writing) and lowered the `timeout-minutes` to 7 minutes.