### PR TITLE
Upgrade percy/exec-action to v0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
           path: dist
 
       - name: Test
-        uses: percy/exec-action@v0.3.0
+        uses: percy/exec-action@v0.3.1
         with:
           custom-command: yarn test:ember:${{ matrix.width }}-${{ matrix.height }} --path=dist
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   build-app:
     name: Build app for testing
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
   lint:
     name: Lint files and dependencies
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 3
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2
@@ -105,7 +105,7 @@ jobs:
           - 'h1'
           - 'h2'
           - 'h3'
-    timeout-minutes: 7
+    timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2
@@ -165,7 +165,7 @@ jobs:
           - 'w3'
         height:
           - 'h3'
-    timeout-minutes: 7
+    timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Recent CI runs produced a deprecation warning message:

```
The `set-env` command is deprecated and will be disabled on November 16th. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

This results from the CI workflow using `v0.3.0` of `percy/exec-action`. Upgrading the action to `v0.3.1` should fix the issue.


## References

- https://github.com/percy/exec-action/releases/tag/v0.3.1