### PR TITLE
Add ember-canary to ember-try test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
           - 'ember-lts-3.20'
           - 'ember-release'
           - 'ember-beta'
+          - 'ember-canary'
         width:
           - 'w1'
           - 'w2'

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -42,6 +42,15 @@ module.exports = async function() {
           }
         }
       },
+      {
+        name: 'ember-canary',
+        allowedToFail: true,
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('canary')
+          }
+        }
+      },
     ]
   };
 };

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,7 +8,6 @@ module.exports = async function() {
     scenarios: [
       {
         name: 'ember-lts-3.16',
-        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': '~3.16.0'
@@ -17,7 +16,6 @@ module.exports = async function() {
       },
       {
         name: 'ember-lts-3.20',
-        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': '~3.20.5'
@@ -26,7 +24,6 @@ module.exports = async function() {
       },
       {
         name: 'ember-release',
-        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('release')
@@ -35,7 +32,6 @@ module.exports = async function() {
       },
       {
         name: 'ember-beta',
-        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta')
@@ -44,7 +40,6 @@ module.exports = async function() {
       },
       {
         name: 'ember-canary',
-        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary')


### PR DESCRIPTION
## Description

Let's check that the addon will work with `ember-canary`, a recommended practice for Ember addons.

I removed `allowedToFail` flag from all test scenarios (even for the canary) so that there may be time to address an issue if found. For context, when I had created the addon, I think I had set `allowedToFail` to `true` for all test scenarios because I didn't understand how CI with `ember-try` should work.