### PR TITLE
Research: Investigate reactivity

### DIFF
--- a/addon/components/container-query.js
+++ b/addon/components/container-query.js
@@ -20,12 +20,8 @@ export default class ContainerQueryComponent extends Component {
     return this.args.debounce ?? 0;
   }
 
-  constructor() {
-    super(...arguments);
-
-    // The dynamic tag is restricted to be immutable
-    this.tagName = this.args.tagName || 'div';
-  }
+  // The dynamic tag is restricted to be immutable
+  tagName = this.args.tagName ?? 'div';
 
   @action queryContainer(element) {
     this.measureDimensions(element);

--- a/addon/components/container-query.js
+++ b/addon/components/container-query.js
@@ -60,18 +60,14 @@ export default class ContainerQueryComponent extends Component {
 
       if (prefix) {
         attributeName = `data-${prefix}-${featureName}`;
-
       } else {
         attributeName = `data-${featureName}`;
-
       }
 
       if (meetsFeature) {
         element.setAttribute(attributeName, '');
-
       } else {
         element.removeAttribute(attributeName);
-
       }
     }
   }

--- a/tests/dummy/app/utils/widgets/widget-2.js
+++ b/tests/dummy/app/utils/widgets/widget-2.js
@@ -47,8 +47,8 @@ export function formatRevenue(revenue) {
 export function createDataForVisualization(rawData) {
   return rawData.map(datum => {
     const musicFormat = datum['Format'];
-    const year = Number(datum['Year']);
-    const revenue = Number(datum['Revenue (Inflation Adjusted)']);
+    const year = parseInt(datum['Year'], 10);
+    const revenue = parseInt(datum['Revenue (Inflation Adjusted)'], 10);
 
     return { musicFormat, year, revenue };
   });
@@ -69,8 +69,8 @@ export function createSummariesForCaptions(rawData) {
 function groupDataByMusicFormat(rawData) {
   return rawData.reduce((accumulator, datum) => {
     const musicFormat = datum['Format'];
-    const year = Number(datum['Year']);
-    const revenue = Number(datum['Revenue (Inflation Adjusted)']);
+    const year = parseInt(datum['Year'], 10);
+    const revenue = parseInt(datum['Revenue (Inflation Adjusted)'], 10);
     const didMusicFormatExist = (revenue !== 0);
 
     if (accumulator[musicFormat]) {

--- a/tests/helpers/container-query.js
+++ b/tests/helpers/container-query.js
@@ -48,7 +48,7 @@ function setupCustomAssertions(assert) {
         'Width and height are correct.'
       );
 
-    const aspectRatio = Number(find('[data-test-aspect-ratio]').textContent.trim());
+    const aspectRatio = parseFloat(find('[data-test-aspect-ratio]').textContent.trim());
     const expectedAspectRatio = expectedWidth / expectedHeight;
     const tolerance = 0.001;
 

--- a/tests/helpers/percy.js
+++ b/tests/helpers/percy.js
@@ -163,7 +163,7 @@ function getWindowSize() {
   const queryParams = new URLSearchParams(window.location.search);
 
   return {
-    height: Number(queryParams.get('height')),
-    width: Number(queryParams.get('width'))
+    height: parseInt(queryParams.get('height'), 10),
+    width: parseInt(queryParams.get('width'), 10)
   };
 }

--- a/tests/integration/components/container-query/dataAttributePrefix-test.js
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.js
@@ -304,4 +304,151 @@ module('Integration | Component | container-query', function(hooks) {
       });
     });
   });
+
+
+  module('When @dataAttributePrefix is updated', function(hooks) {
+    hooks.beforeEach(async function() {
+      this.dataAttributePrefix = 'cq1';
+
+      await render(hbs`
+        <div
+          data-test-parent-element
+          style="width: 250px; height: 500px;"
+        >
+          <ContainerQuery
+            @features={{hash
+              small=(cq-width max=300)
+              medium=(cq-width min=300 max=600)
+              large=(cq-width min=600 max=900)
+              short=(cq-height max=500)
+              tall=(cq-height min=500)
+              ratio-type-A=(cq-aspect-ratio min=0.25 max=0.75)
+              ratio-type-B=(cq-aspect-ratio min=0.5 max=1.5)
+              ratio-type-C=(cq-aspect-ratio min=1.25 max=2)
+            }}
+            @dataAttributePrefix={{this.dataAttributePrefix}}
+            as |CQ|
+          >
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
+
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
+
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
+          </ContainerQuery>
+        </div>
+      `);
+
+      this.set('dataAttributePrefix', 'cq2');
+    });
+
+
+    test('The component doesn\'t update the data attributes', async function(assert) {
+      assert.areDataAttributesCorrect({
+        'data-cq1-small': '',
+        'data-cq1-medium': undefined,
+        'data-cq1-large': undefined,
+        'data-cq1-short': undefined,
+        'data-cq1-tall': '',
+        'data-cq1-ratio-type-A': '',
+        'data-cq1-ratio-type-B': '',
+        'data-cq1-ratio-type-C': undefined
+      });
+
+      assert.areDataAttributesCorrect({
+        'data-cq2-small': undefined,
+        'data-cq2-medium': undefined,
+        'data-cq2-large': undefined,
+        'data-cq2-short': undefined,
+        'data-cq2-tall': undefined,
+        'data-cq2-ratio-type-A': undefined,
+        'data-cq2-ratio-type-B': undefined,
+        'data-cq2-ratio-type-C': undefined
+      });
+    });
+
+
+    test('The component updates the data attributes when it is resized', async function(assert) {
+      await resizeContainer(500, 300);
+
+      assert.areDataAttributesCorrect({
+        'data-cq1-small': '',
+        'data-cq1-medium': undefined,
+        'data-cq1-large': undefined,
+        'data-cq1-short': undefined,
+        'data-cq1-tall': '',
+        'data-cq1-ratio-type-A': '',
+        'data-cq1-ratio-type-B': '',
+        'data-cq1-ratio-type-C': undefined
+      });
+
+      assert.areDataAttributesCorrect({
+        'data-cq2-small': undefined,
+        'data-cq2-medium': '',
+        'data-cq2-large': undefined,
+        'data-cq2-short': '',
+        'data-cq2-tall': undefined,
+        'data-cq2-ratio-type-A': undefined,
+        'data-cq2-ratio-type-B': undefined,
+        'data-cq2-ratio-type-C': ''
+      });
+
+
+      await resizeContainer(800, 400);
+
+      assert.areDataAttributesCorrect({
+        'data-cq1-small': '',
+        'data-cq1-medium': undefined,
+        'data-cq1-large': undefined,
+        'data-cq1-short': undefined,
+        'data-cq1-tall': '',
+        'data-cq1-ratio-type-A': '',
+        'data-cq1-ratio-type-B': '',
+        'data-cq1-ratio-type-C': undefined
+      });
+
+      assert.areDataAttributesCorrect({
+        'data-cq2-small': undefined,
+        'data-cq2-medium': undefined,
+        'data-cq2-large': '',
+        'data-cq2-short': '',
+        'data-cq2-tall': undefined,
+        'data-cq2-ratio-type-A': undefined,
+        'data-cq2-ratio-type-B': undefined,
+        'data-cq2-ratio-type-C': undefined
+      });
+
+
+      await resizeContainer(1000, 600);
+
+      assert.areDataAttributesCorrect({
+        'data-cq1-small': '',
+        'data-cq1-medium': undefined,
+        'data-cq1-large': undefined,
+        'data-cq1-short': undefined,
+        'data-cq1-tall': '',
+        'data-cq1-ratio-type-A': '',
+        'data-cq1-ratio-type-B': '',
+        'data-cq1-ratio-type-C': undefined
+      });
+
+      assert.areDataAttributesCorrect({
+        'data-cq2-small': undefined,
+        'data-cq2-medium': undefined,
+        'data-cq2-large': undefined,
+        'data-cq2-short': undefined,
+        'data-cq2-tall': '',
+        'data-cq2-ratio-type-A': undefined,
+        'data-cq2-ratio-type-B': undefined,
+        'data-cq2-ratio-type-C': ''
+      });
+    });
+  });
 });

--- a/tests/integration/components/container-query/features-test.js
+++ b/tests/integration/components/container-query/features-test.js
@@ -232,4 +232,151 @@ module('Integration | Component | container-query', function(hooks) {
       assert.areDimensionsCorrect(1000, 600);
     });
   });
+
+
+  module('When @features is updated', function(hooks) {
+    hooks.beforeEach(async function() {
+      this.features = {
+        small: {
+          dimension: 'width',
+          min: 0,
+          max: 300
+        },
+        medium: {
+          dimension: 'width',
+          min: 300,
+          max: 600
+        },
+        short: {
+          dimension: 'height',
+          min: 0,
+          max: 500
+        },
+        'ratio-type-C': {
+          dimension: 'aspectRatio',
+          min: 1.25,
+          max: 2
+        }
+      };
+
+      await render(hbs`
+        <div
+          data-test-parent-element
+          style="width: 250px; height: 500px;"
+        >
+          <ContainerQuery
+            @features={{this.features}}
+            as |CQ|
+          >
+            <p data-test-feature="small">{{CQ.features.small}}</p>
+            <p data-test-feature="medium">{{CQ.features.medium}}</p>
+            <p data-test-feature="large">{{CQ.features.large}}</p>
+
+            <p data-test-feature="short">{{CQ.features.short}}</p>
+            <p data-test-feature="tall">{{CQ.features.tall}}</p>
+
+            <p data-test-feature="ratio-type-A">{{CQ.features.ratio-type-A}}</p>
+            <p data-test-feature="ratio-type-B">{{CQ.features.ratio-type-B}}</p>
+            <p data-test-feature="ratio-type-C">{{CQ.features.ratio-type-C}}</p>
+
+            <p data-test-width-height>{{CQ.dimensions.width}} x {{CQ.dimensions.height}}</p>
+            <p data-test-aspect-ratio>{{CQ.dimensions.aspectRatio}}</p>
+          </ContainerQuery>
+        </div>
+      `);
+
+      this.set('features', {
+        large: {
+          dimension: 'width',
+          min: 600,
+          max: 900
+        },
+        tall: {
+          dimension: 'height',
+          min: 500,
+          max: Infinity
+        },
+        'ratio-type-A': {
+          dimension: 'aspectRatio',
+          min: 0.25,
+          max: 0.75
+        },
+        'ratio-type-B': {
+          dimension: 'aspectRatio',
+          min: 0.5,
+          max: 1.5
+        }
+      });
+    });
+
+
+    test('The component doesn\'t update the features', async function(assert) {
+      assert.areFeaturesCorrect({
+        small: true,
+        medium: false,
+        short: false,
+        'ratio-type-C': false
+      });
+
+      assert.areFeaturesCorrect({
+        large: undefined,
+        tall: undefined,
+        'ratio-type-A': undefined,
+        'ratio-type-B': undefined
+      });
+    });
+
+
+    test('The component updates features when it is resized', async function(assert) {
+      await resizeContainer(500, 300);
+
+      assert.areFeaturesCorrect({
+        small: undefined,
+        medium: undefined,
+        short: undefined,
+        'ratio-type-C': undefined
+      });
+
+      assert.areFeaturesCorrect({
+        large: false,
+        tall: false,
+        'ratio-type-A': false,
+        'ratio-type-B': false
+      });
+
+
+      await resizeContainer(800, 400);
+
+      assert.areFeaturesCorrect({
+        small: undefined,
+        medium: undefined,
+        short: undefined,
+        'ratio-type-C': undefined
+      });
+
+      assert.areFeaturesCorrect({
+        large: true,
+        tall: false,
+        'ratio-type-A': false,
+        'ratio-type-B': false
+      });
+
+
+      await resizeContainer(1000, 600);
+
+      assert.areFeaturesCorrect({
+        small: undefined,
+        medium: undefined,
+        short: undefined,
+        'ratio-type-C': undefined
+      });
+
+      assert.areFeaturesCorrect({
+        large: false,
+        tall: true,
+        'ratio-type-A': false,
+        'ratio-type-B': false
+      });
+    });
+  });
 });

--- a/tests/integration/components/container-query/tagName-test.js
+++ b/tests/integration/components/container-query/tagName-test.js
@@ -1,5 +1,4 @@
-import { set } from '@ember/object';
-import { render, settled } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
 import resizeContainer from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
@@ -184,9 +183,7 @@ module('Integration | Component | container-query', function(hooks) {
         </div>
       `);
 
-      set(this, 'tagName', 'article');
-
-      await settled();
+      this.set('tagName', 'article');
     });
 
 


### PR DESCRIPTION
## Description

When I had created the addon, I didn't account for what would happen if the argument `@dataAttributePrefix` or `@features` is updated after the component is rendered. At the moment, I can't think of practical uses for updating either argument.

If we don't want developers to update `@dataAttributePrefix` and `@features` (similarly to `@tagName`, which was considered to be immutable from the start), we should update the documentation (e.g. `README`, tests) to indicate so.

If we do want to allow developers to update them (or maybe because we expect getters to recompute when an argument is updated), then we'll need to ensure that data attributes are added and removed correctly when either `@dataAttributePrefix` or `@features` is updated. I wasn't able to find a simple solution in my initial attempt.