### PR TITLE
Fix brittle tests

### DIFF
--- a/tests/acceptance/dashboard/visual-regression-test.js
+++ b/tests/acceptance/dashboard/visual-regression-test.js
@@ -1,6 +1,7 @@
 import { visit } from '@ember/test-helpers';
 import takeSnapshot from 'dummy/tests/helpers/percy';
 import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { timeout } from 'dummy/tests/helpers/resize-container';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -11,6 +12,7 @@ module('Acceptance | dashboard', function(hooks) {
 
   test('@w1 @h1 Visual snapshot', async function(assert) {
     await visit('/dashboard');
+    await timeout(100);
 
 
     // Widget 1
@@ -218,6 +220,7 @@ module('Acceptance | dashboard', function(hooks) {
 
   test('@w1 @h2 Visual snapshot', async function(assert) {
     await visit('/dashboard');
+    await timeout(100);
 
 
     // Widget 1

--- a/tests/dummy/app/components/widgets/widget-2/index.hbs
+++ b/tests/dummy/app/components/widgets/widget-2/index.hbs
@@ -1,7 +1,7 @@
 <ContainerQuery
   @features={{hash
-    short=(cq-height max=200)
-    tall=(cq-height min=200 max=480)
+    short=(cq-height max=240)
+    tall=(cq-height min=240 max=480)
     very-tall=(cq-height min=480)
   }}
   @tagName="section"


### PR DESCRIPTION
## Description

In continuous integration, the following 2 tests have been failing for a couple of months now:

- `Acceptance | dashboard > @w1 @h1 Visual snapshot`
- `Acceptance | dashboard > @w1 @h2 Visual snapshot`

While the root cause is still unknown (perhaps a change in the Chrome browser?), I found that we can take these small actions to get all tests passing again:

- Update the features of `<Widgets::Widget2>` component
- Add a timeout after rendering the dashboard page for `w1-h1` and `w1-h2` devices

While this solution isn't ideal, I think it's important to get continuous integration running again, to assure the end-users that it's okay to use `ember-container-query` in their app or addon. We can continue to look into the underlying issue.