### PR TITLE
Added 3.24 LTS to ember-try scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
         scenario:
           - 'ember-lts-3.16'
           - 'ember-lts-3.20'
+          - 'ember-lts-3.24'
           - 'ember-release'
           - 'ember-beta'
           - 'ember-canary'

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -23,6 +23,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-3.24',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.24.3',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
## Notes

Ember 3.24 has become an LTS (long-term support) version on February 25, 2021.

Since March 17, 2021, Ember 3.16 LTS is no longer supported. Since there may be developers who are working on an app that is 3.16 or earlier, I will continue to run Ember 3.16 in CI for some additional time.