### PR TITLE
Added embroider-safe to ember-try scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,8 @@ jobs:
           - 'ember-release'
           - 'ember-beta'
           - 'ember-canary'
+          - 'embroider-optimized'
+          - 'embroider-safe'
         width:
           - 'w1'
           - 'w2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
           - 'ember-release'
           - 'ember-beta'
           - 'ember-canary'
-          - 'embroider-optimized'
+          # - 'embroider-optimized'
           - 'embroider-safe'
         width:
           - 'w1'

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { embroiderOptimized, embroiderSafe } = require('@embroider/test-setup');
 const getChannelURL = require('ember-source-channel-url');
 
 module.exports = async function () {
@@ -54,6 +55,8 @@ module.exports = async function () {
           },
         },
       },
+      embroiderOptimized(),
+      embroiderSafe(),
     ],
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { maybeEmbroider } = require('@embroider/test-setup');
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function (defaults) {
@@ -18,5 +19,5 @@ module.exports = function (defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return app.toTree();
+  return maybeEmbroider(app);
 };

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
+    "@embroider/test-setup": "^0.39.1",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "@percy/cli": "^1.0.0-beta.48",

--- a/tests/integration/components/container-query/splattributes-test.js
+++ b/tests/integration/components/container-query/splattributes-test.js
@@ -10,7 +10,7 @@ module('Integration | Component | container-query', function (hooks) {
 
   module('...attributes', function () {
     test('The component accepts splattributes', async function (assert) {
-      assert.expect(3);
+      assert.expect(2);
 
       this.fetchData = () => {
         assert.ok(
@@ -34,7 +34,6 @@ module('Integration | Component | container-query', function (hooks) {
             }}
 
             class="unique-class-name"
-            local-class="container"
             {{did-insert this.fetchData}}
 
             as |CQ|
@@ -58,8 +57,7 @@ module('Integration | Component | container-query', function (hooks) {
 
       assert
         .dom('[data-test-container-query]')
-        .hasClass('unique-class-name', 'Providing a custom CSS class works.')
-        .hasAttribute('local-class', 'container', 'ember-css-modules works.');
+        .hasClass('unique-class-name', 'Providing a custom CSS class works.');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,6 +1080,14 @@
     semver "^7.3.2"
     typescript-memoize "^1.0.0-alpha.3"
 
+"@embroider/test-setup@^0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.39.1.tgz#3b87c9a3a029711f43f7ac89952eaaddf30196fd"
+  integrity sha512-EYlsiPiK6FfxeB9Yq9/c/dXwTjo1T5xD6UUfK6rv0PLGP5W1OqYd0Kyf8LGpLKeaRzLD6GfOeb+GXpx9IgPyeg==
+  dependencies:
+    lodash "^4.17.20"
+    resolve "^1.17.0"
+
 "@embroider/util@^0.39.1":
   version "0.39.1"
   resolved "https://registry.yarnpkg.com/@embroider/util/-/util-0.39.1.tgz#7cec8ea13d8ce73539179d47d2564d8c09d055f6"
@@ -9040,7 +9048,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.6.1, lodash@^4.7.0:
+lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.6.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Description

I followed the [Addon Author Guide](https://github.com/embroider-build/embroider/blob/master/ADDON-AUTHOR-GUIDE.md) to understand what I could do to prepare for Embroider landing.

I wanted to add both `embroider-safe` and `embroider-optimized` scenarios, but the latter wouldn't pass in CI. There may be two explanations:

1. I was using v0.4.0 of `ember-element-helper`.

    ```sh
    Unsafe dynamic component: cannot statically analyze this expression in $TMPDIR/embroider/6871bd/components/container-query.hbs/container-query.hbs
    ```

     Updating the addon to v0.5.0 (in #80) fixed the error above.

2. `ember-css-modules`, which is used in the demo app, is not compatible with Embroider yet (https://github.com/salsify/ember-css-modules/issues/140, https://github.com/salsify/ember-css-modules/issues/160)

    ```sh
    Unable to resolve local class names from dummy/components/navigation-menu/index.css; does the styles file exist?
    ```

I tried changing the components folder structure from nested to flat, in case this might help Embroider understand `ember-css-modules`. Changing the folder structure didn't seem to have an effect.

For now, let's check just the `embroider-safe` scenario.


## References

- [RFC #507: v2 Addon Format](https://github.com/emberjs/rfcs/pull/507)
- [README for `@ember/test-setup`](https://github.com/embroider-build/embroider/tree/master/packages/test-setup)
- [Addon Author Guide](https://github.com/embroider-build/embroider/blob/master/ADDON-AUTHOR-GUIDE.md)
- [Embroider support from `ember-element-helper`](https://github.com/tildeio/ember-element-helper/pull/34)