### PR TITLE
Dropped support for 3.16 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,6 @@ jobs:
     strategy:
       matrix:
         scenario:
-          - 'ember-lts-3.16'
           - 'ember-lts-3.20'
           - 'ember-lts-3.24'
           - 'ember-release'

--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ For more examples, I encourage you to check out the code for my demo app. It is 
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.16 or above<sup>1</sup> (3.12 - 3.15 may work but won't be supported)
-* Ember CLI v2.13 or above
+* Ember.js v3.20 or above<sup>1</sup>
+* Ember CLI v3.20 or above
 * Node.js v10 or above
 * Modern browsers<sup>1</sup> (IE 11 won't be supported)
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,14 +8,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.16',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.16.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.20',
         npm: {
           devDependencies: {


### PR DESCRIPTION
## Description

Support for Ember 3.16 LTS was [dropped on March 17, 2021](https://github.com/ember-learn/ember-website/issues/788).