### PR TITLE
Dropped support for Node 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Compatibility
 
 * Ember.js v3.20 or above<sup>1</sup>
 * Ember CLI v3.20 or above
-* Node.js v10 or above
+* Node.js v12 or above
 * Modern browsers<sup>1</sup> (IE 11 won't be supported)
 
 <sup>1. Until you can adopt Ember Octane and drop support for IE 11, I recommend using [`ember-fill-up`](https://github.com/chadian/ember-fill-up) to do container queries. The APIs are similar so your migration should be smooth. Chad Carbert and I will ensure that the addons are maintained side-by-side for some time.</sup>

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "webpack": "^5.51.1"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "12.* || >= 14"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## Description

Support for Node 10 LTS was [dropped on April 30, 2021](https://github.com/nodejs/Release/pull/664).