### PR TITLE
Replaced custom caching strategy with one built into @actions/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
     needs: [build-app]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         width:
           - 'w1'
@@ -111,6 +112,7 @@ jobs:
     name: Test compatibility
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         scenario:
           - 'ember-lts-3.20'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,25 +26,11 @@ jobs:
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
+          cache: 'yarn'
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Get Yarn cache path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache Yarn cache and node_modules
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-${{ env.NODE_VERSION }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
       - name: Build app
         run: yarn build:test
@@ -67,25 +53,11 @@ jobs:
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
+          cache: 'yarn'
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Get Yarn cache path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache Yarn cache and node_modules
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-${{ env.NODE_VERSION }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
       - name: Lint
         run: yarn lint
@@ -113,25 +85,11 @@ jobs:
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
+          cache: 'yarn'
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Get Yarn cache path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache Yarn cache and node_modules
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-${{ env.NODE_VERSION }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
       - name: Download app
         uses: actions/download-artifact@v2
@@ -176,25 +134,11 @@ jobs:
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v2
         with:
+          cache: 'yarn'
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Get Yarn cache path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache Yarn cache and node_modules
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ matrix.scenario }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ matrix.scenario }}-
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
       # Test compatibility without Percy
       - name: Test

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { embroiderOptimized, embroiderSafe } = require('@embroider/test-setup');
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderOptimized, embroiderSafe } = require('@embroider/test-setup');
 
 module.exports = async function () {
   return {
@@ -27,7 +27,8 @@ module.exports = async function () {
         name: 'ember-release',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('release'),
+            'ember-source': '~3.28.8',
+            // 'ember-source': await getChannelURL('release'),
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:ember:w1-h3": "DEVICE='w1-h3' percy exec -- ember test --test-port=7363",
     "test:ember:w2-h3": "DEVICE='w2-h3' percy exec -- ember test --test-port=7364",
     "test:ember:w3-h3": "DEVICE='w3-h3' percy exec -- ember test --test-port=7365",
-    "test:ember-compatibility": "ember try:one"
+    "test:ember-compatibility": "./node_modules/.bin/ember try:one"
   },
   "changelog": {
     "labels": {


### PR DESCRIPTION
## Description

The scheduled CI failed for a month. I think the main reason was cached lockfile containing an incorrect `ember-source`:

```sh
# CI (#444): Test compatibility (ember-release, w1, h3)

$ ember try:one ember-release --- yarn test:ember:w1-h3

Missing yarn packages: 
Package: ember-source
  * Specified: ~3.28.6
  * Installed: 3.28.6-release+5ec85ec0

Run `yarn` to install missing dependencies.
```

I replaced the custom caching strategy with `cache: yarn` option that is provided by `@actions/setup-node`.

In addition, I temporarily changed what `ember-release` points to (latest version of `v3.28`). When `ember-release` points to `v4.0` instead, I encountered the following error:

```sh
# CI (#447): Test compatibility (ember-release, w1, h3)

not ok 1 Chrome 96.0 - [undefined ms] - Global error: Uncaught ReferenceError: Ember is not defined at http://localhost:7363/assets/vendor.js, line 64223
  ---
    browser log: |
      {"type":"error","text":"Uncaught ReferenceError: Ember is not defined at http://localhost:7363/assets/vendor.js, line 64223\n","testContext":{}}
```


## References

- https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
- https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows
- https://github.com/ember-cli/ember-cli/blob/v4.0.0-beta.2/blueprints/addon/files/.github/workflows/ci.yml#L44-L73