### PR TITLE
Applied timeout to all rendering and application tests

### DIFF
--- a/tests/acceptance/album/accessibility-test.js
+++ b/tests/acceptance/album/accessibility-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { timeout } from 'dummy/tests/helpers/resize-container';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -8,64 +9,60 @@ module('Acceptance | album', function (hooks) {
   setupApplicationTest(hooks);
   resetViewport(hooks);
 
-  test('@w1 @h1 Accessibility audit', async function (assert) {
+  hooks.beforeEach(async function () {
     await visit('/album');
+    await timeout();
+  });
+
+  test('@w1 @h1 Accessibility audit', async function (assert) {
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h1 Accessibility audit', async function (assert) {
-    await visit('/album');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h1 Accessibility audit', async function (assert) {
-    await visit('/album');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w1 @h2 Accessibility audit', async function (assert) {
-    await visit('/album');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h2 Accessibility audit', async function (assert) {
-    await visit('/album');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h2 Accessibility audit', async function (assert) {
-    await visit('/album');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w1 @h3 Accessibility audit', async function (assert) {
-    await visit('/album');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h3 Accessibility audit', async function (assert) {
-    await visit('/album');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h3 Accessibility audit', async function (assert) {
-    await visit('/album');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');

--- a/tests/acceptance/album/visual-regression-test.js
+++ b/tests/acceptance/album/visual-regression-test.js
@@ -1,6 +1,7 @@
 import { visit } from '@ember/test-helpers';
 import takeSnapshot from 'dummy/tests/helpers/percy';
 import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { timeout } from 'dummy/tests/helpers/resize-container';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -8,9 +9,12 @@ module('Acceptance | album', function (hooks) {
   setupApplicationTest(hooks);
   resetViewport(hooks);
 
-  test('@w1 @h1 Visual snapshot', async function (assert) {
+  hooks.beforeEach(async function () {
     await visit('/album');
+    await timeout();
+  });
 
+  test('@w1 @h1 Visual snapshot', async function (assert) {
     assert
       .dom('[data-test-list="Tracks"]')
       .exists('We see the album tracks in a list.')
@@ -28,8 +32,6 @@ module('Acceptance | album', function (hooks) {
   });
 
   test('@w2 @h1 Visual snapshot', async function (assert) {
-    await visit('/album');
-
     assert
       .dom('[data-test-list="Tracks"]')
       .exists('We see the album tracks in a list.')
@@ -47,8 +49,6 @@ module('Acceptance | album', function (hooks) {
   });
 
   test('@w3 @h1 Visual snapshot', async function (assert) {
-    await visit('/album');
-
     assert
       .dom('[data-test-list="Tracks"]')
       .exists('We see the album tracks in a list.')
@@ -66,8 +66,6 @@ module('Acceptance | album', function (hooks) {
   });
 
   test('@w1 @h2 Visual snapshot', async function (assert) {
-    await visit('/album');
-
     assert
       .dom('[data-test-list="Tracks"]')
       .exists('We see the album tracks in a list.')
@@ -85,8 +83,6 @@ module('Acceptance | album', function (hooks) {
   });
 
   test('@w2 @h2 Visual snapshot', async function (assert) {
-    await visit('/album');
-
     assert
       .dom('[data-test-list="Tracks"]')
       .exists('We see the album tracks in a list.')
@@ -104,8 +100,6 @@ module('Acceptance | album', function (hooks) {
   });
 
   test('@w3 @h2 Visual snapshot', async function (assert) {
-    await visit('/album');
-
     assert
       .dom('[data-test-table="Tracks"]')
       .exists('We see the album tracks in a table.');
@@ -122,8 +116,6 @@ module('Acceptance | album', function (hooks) {
   });
 
   test('@w1 @h3 Visual snapshot', async function (assert) {
-    await visit('/album');
-
     assert
       .dom('[data-test-list="Tracks"]')
       .exists('We see the album tracks in a list.')
@@ -141,8 +133,6 @@ module('Acceptance | album', function (hooks) {
   });
 
   test('@w2 @h3 Visual snapshot', async function (assert) {
-    await visit('/album');
-
     assert
       .dom('[data-test-table="Tracks"]')
       .exists('We see the album tracks in a table.');
@@ -159,8 +149,6 @@ module('Acceptance | album', function (hooks) {
   });
 
   test('@w3 @h3 Visual snapshot', async function (assert) {
-    await visit('/album');
-
     assert
       .dom('[data-test-table="Tracks"]')
       .exists('We see the album tracks in a table.');

--- a/tests/acceptance/dashboard/accessibility-test.js
+++ b/tests/acceptance/dashboard/accessibility-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { timeout } from 'dummy/tests/helpers/resize-container';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -8,64 +9,60 @@ module('Acceptance | dashboard', function (hooks) {
   setupApplicationTest(hooks);
   resetViewport(hooks);
 
-  test('@w1 @h1 Accessibility audit', async function (assert) {
+  hooks.beforeEach(async function () {
     await visit('/dashboard');
+    await timeout();
+  });
+
+  test('@w1 @h1 Accessibility audit', async function (assert) {
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h1 Accessibility audit', async function (assert) {
-    await visit('/dashboard');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h1 Accessibility audit', async function (assert) {
-    await visit('/dashboard');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w1 @h2 Accessibility audit', async function (assert) {
-    await visit('/dashboard');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h2 Accessibility audit', async function (assert) {
-    await visit('/dashboard');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h2 Accessibility audit', async function (assert) {
-    await visit('/dashboard');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w1 @h3 Accessibility audit', async function (assert) {
-    await visit('/dashboard');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h3 Accessibility audit', async function (assert) {
-    await visit('/dashboard');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h3 Accessibility audit', async function (assert) {
-    await visit('/dashboard');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');

--- a/tests/acceptance/dashboard/visual-regression-test.js
+++ b/tests/acceptance/dashboard/visual-regression-test.js
@@ -9,10 +9,12 @@ module('Acceptance | dashboard', function (hooks) {
   setupApplicationTest(hooks);
   resetViewport(hooks);
 
-  test('@w1 @h1 Visual snapshot', async function (assert) {
+  hooks.beforeEach(async function () {
     await visit('/dashboard');
-    await timeout(100);
+    await timeout();
+  });
 
+  test('@w1 @h1 Visual snapshot', async function (assert) {
     // Widget 1
     assert
       .dom('[data-test-widget="1"] [data-test-container-query]')
@@ -99,8 +101,6 @@ module('Acceptance | dashboard', function (hooks) {
   });
 
   test('@w2 @h1 Visual snapshot', async function (assert) {
-    await visit('/dashboard');
-
     // Widget 1
     assert
       .dom('[data-test-widget="1"] [data-test-container-query]')
@@ -187,8 +187,6 @@ module('Acceptance | dashboard', function (hooks) {
   });
 
   test('@w3 @h1 Visual snapshot', async function (assert) {
-    await visit('/dashboard');
-
     // Widget 1
     assert
       .dom('[data-test-widget="1"] [data-test-container-query]')
@@ -287,9 +285,6 @@ module('Acceptance | dashboard', function (hooks) {
   });
 
   test('@w1 @h2 Visual snapshot', async function (assert) {
-    await visit('/dashboard');
-    await timeout(100);
-
     // Widget 1
     assert
       .dom('[data-test-widget="1"] [data-test-container-query]')
@@ -376,8 +371,6 @@ module('Acceptance | dashboard', function (hooks) {
   });
 
   test('@w2 @h2 Visual snapshot', async function (assert) {
-    await visit('/dashboard');
-
     // Widget 1
     assert
       .dom('[data-test-widget="1"] [data-test-container-query]')
@@ -464,8 +457,6 @@ module('Acceptance | dashboard', function (hooks) {
   });
 
   test('@w3 @h2 Visual snapshot', async function (assert) {
-    await visit('/dashboard');
-
     // Widget 1
     assert
       .dom('[data-test-widget="1"] [data-test-container-query]')
@@ -564,8 +555,6 @@ module('Acceptance | dashboard', function (hooks) {
   });
 
   test('@w1 @h3 Visual snapshot', async function (assert) {
-    await visit('/dashboard');
-
     // Widget 1
     assert
       .dom('[data-test-widget="1"] [data-test-container-query]')
@@ -661,8 +650,6 @@ module('Acceptance | dashboard', function (hooks) {
   });
 
   test('@w2 @h3 Visual snapshot', async function (assert) {
-    await visit('/dashboard');
-
     // Widget 1
     assert
       .dom('[data-test-widget="1"] [data-test-container-query]')
@@ -749,8 +736,6 @@ module('Acceptance | dashboard', function (hooks) {
   });
 
   test('@w3 @h3 Visual snapshot', async function (assert) {
-    await visit('/dashboard');
-
     // Widget 1
     assert
       .dom('[data-test-widget="1"] [data-test-container-query]')

--- a/tests/acceptance/form/accessibility-test.js
+++ b/tests/acceptance/form/accessibility-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { timeout } from 'dummy/tests/helpers/resize-container';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -8,64 +9,60 @@ module('Acceptance | form', function (hooks) {
   setupApplicationTest(hooks);
   resetViewport(hooks);
 
-  test('@w1 @h1 Accessibility audit', async function (assert) {
+  hooks.beforeEach(async function () {
     await visit('/form');
+    await timeout();
+  });
+
+  test('@w1 @h1 Accessibility audit', async function (assert) {
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h1 Accessibility audit', async function (assert) {
-    await visit('/form');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h1 Accessibility audit', async function (assert) {
-    await visit('/form');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w1 @h2 Accessibility audit', async function (assert) {
-    await visit('/form');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h2 Accessibility audit', async function (assert) {
-    await visit('/form');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h2 Accessibility audit', async function (assert) {
-    await visit('/form');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w1 @h3 Accessibility audit', async function (assert) {
-    await visit('/form');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h3 Accessibility audit', async function (assert) {
-    await visit('/form');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h3 Accessibility audit', async function (assert) {
-    await visit('/form');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');

--- a/tests/acceptance/form/visual-regression-test.js
+++ b/tests/acceptance/form/visual-regression-test.js
@@ -1,6 +1,7 @@
 import { visit } from '@ember/test-helpers';
 import takeSnapshot from 'dummy/tests/helpers/percy';
 import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { timeout } from 'dummy/tests/helpers/resize-container';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
@@ -8,64 +9,60 @@ module('Acceptance | form', function (hooks) {
   setupApplicationTest(hooks);
   resetViewport(hooks);
 
-  test('@w1 @h1 Visual snapshot', async function (assert) {
+  hooks.beforeEach(async function () {
     await visit('/form');
+    await timeout();
+  });
+
+  test('@w1 @h1 Visual snapshot', async function (assert) {
     await takeSnapshot(assert);
 
     assert.ok(true);
   });
 
   test('@w2 @h1 Visual snapshot', async function (assert) {
-    await visit('/form');
     await takeSnapshot(assert);
 
     assert.ok(true);
   });
 
   test('@w3 @h1 Visual snapshot', async function (assert) {
-    await visit('/form');
     await takeSnapshot(assert);
 
     assert.ok(true);
   });
 
   test('@w1 @h2 Visual snapshot', async function (assert) {
-    await visit('/form');
     await takeSnapshot(assert);
 
     assert.ok(true);
   });
 
   test('@w2 @h2 Visual snapshot', async function (assert) {
-    await visit('/form');
     await takeSnapshot(assert);
 
     assert.ok(true);
   });
 
   test('@w3 @h2 Visual snapshot', async function (assert) {
-    await visit('/form');
     await takeSnapshot(assert);
 
     assert.ok(true);
   });
 
   test('@w1 @h3 Visual snapshot', async function (assert) {
-    await visit('/form');
     await takeSnapshot(assert);
 
     assert.ok(true);
   });
 
   test('@w2 @h3 Visual snapshot', async function (assert) {
-    await visit('/form');
     await takeSnapshot(assert);
 
     assert.ok(true);
   });
 
   test('@w3 @h3 Visual snapshot', async function (assert) {
-    await visit('/form');
     await takeSnapshot(assert);
 
     assert.ok(true);

--- a/tests/acceptance/form/visual-regression-test.js
+++ b/tests/acceptance/form/visual-regression-test.js
@@ -15,56 +15,128 @@ module('Acceptance | form', function (hooks) {
   });
 
   test('@w1 @h1 Visual snapshot', async function (assert) {
-    await takeSnapshot(assert);
+    assert
+      .dom('[data-test-form="Contact me"]')
+      .exists('We see the contact form.');
 
-    assert.ok(true);
+    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
+
+    assert
+      .dom('[data-test-button="Submit"]')
+      .hasText('Submit', 'We see the submit button.');
+
+    await takeSnapshot(assert);
   });
 
   test('@w2 @h1 Visual snapshot', async function (assert) {
-    await takeSnapshot(assert);
+    assert
+      .dom('[data-test-form="Contact me"]')
+      .exists('We see the contact form.');
 
-    assert.ok(true);
+    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
+
+    assert
+      .dom('[data-test-button="Submit"]')
+      .hasText('Submit', 'We see the submit button.');
+
+    await takeSnapshot(assert);
   });
 
   test('@w3 @h1 Visual snapshot', async function (assert) {
-    await takeSnapshot(assert);
+    assert
+      .dom('[data-test-form="Contact me"]')
+      .exists('We see the contact form.');
 
-    assert.ok(true);
+    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
+
+    assert
+      .dom('[data-test-button="Submit"]')
+      .hasText('Submit', 'We see the submit button.');
+
+    await takeSnapshot(assert);
   });
 
   test('@w1 @h2 Visual snapshot', async function (assert) {
-    await takeSnapshot(assert);
+    assert
+      .dom('[data-test-form="Contact me"]')
+      .exists('We see the contact form.');
 
-    assert.ok(true);
+    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
+
+    assert
+      .dom('[data-test-button="Submit"]')
+      .hasText('Submit', 'We see the submit button.');
+
+    await takeSnapshot(assert);
   });
 
   test('@w2 @h2 Visual snapshot', async function (assert) {
-    await takeSnapshot(assert);
+    assert
+      .dom('[data-test-form="Contact me"]')
+      .exists('We see the contact form.');
 
-    assert.ok(true);
+    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
+
+    assert
+      .dom('[data-test-button="Submit"]')
+      .hasText('Submit', 'We see the submit button.');
+
+    await takeSnapshot(assert);
   });
 
   test('@w3 @h2 Visual snapshot', async function (assert) {
-    await takeSnapshot(assert);
+    assert
+      .dom('[data-test-form="Contact me"]')
+      .exists('We see the contact form.');
 
-    assert.ok(true);
+    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
+
+    assert
+      .dom('[data-test-button="Submit"]')
+      .hasText('Submit', 'We see the submit button.');
+
+    await takeSnapshot(assert);
   });
 
   test('@w1 @h3 Visual snapshot', async function (assert) {
-    await takeSnapshot(assert);
+    assert
+      .dom('[data-test-form="Contact me"]')
+      .exists('We see the contact form.');
 
-    assert.ok(true);
+    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
+
+    assert
+      .dom('[data-test-button="Submit"]')
+      .hasText('Submit', 'We see the submit button.');
+
+    await takeSnapshot(assert);
   });
 
   test('@w2 @h3 Visual snapshot', async function (assert) {
-    await takeSnapshot(assert);
+    assert
+      .dom('[data-test-form="Contact me"]')
+      .exists('We see the contact form.');
 
-    assert.ok(true);
+    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
+
+    assert
+      .dom('[data-test-button="Submit"]')
+      .hasText('Submit', 'We see the submit button.');
+
+    await takeSnapshot(assert);
   });
 
   test('@w3 @h3 Visual snapshot', async function (assert) {
-    await takeSnapshot(assert);
+    assert
+      .dom('[data-test-form="Contact me"]')
+      .exists('We see the contact form.');
 
-    assert.ok(true);
+    assert.dom('[data-test-field]').exists({ count: 4 }, 'We see 4 fields.');
+
+    assert
+      .dom('[data-test-button="Submit"]')
+      .hasText('Submit', 'We see the submit button.');
+
+    await takeSnapshot(assert);
   });
 });

--- a/tests/acceptance/index/accessibility-test.js
+++ b/tests/acceptance/index/accessibility-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { timeout } from 'dummy/tests/helpers/resize-container';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -8,64 +9,60 @@ module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
   resetViewport(hooks);
 
-  test('@w1 @h1 Accessibility audit', async function (assert) {
+  hooks.beforeEach(async function () {
     await visit('/');
+    await timeout();
+  });
+
+  test('@w1 @h1 Accessibility audit', async function (assert) {
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h1 Accessibility audit', async function (assert) {
-    await visit('/');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h1 Accessibility audit', async function (assert) {
-    await visit('/');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w1 @h2 Accessibility audit', async function (assert) {
-    await visit('/');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h2 Accessibility audit', async function (assert) {
-    await visit('/');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h2 Accessibility audit', async function (assert) {
-    await visit('/');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w1 @h3 Accessibility audit', async function (assert) {
-    await visit('/');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h3 Accessibility audit', async function (assert) {
-    await visit('/');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h3 Accessibility audit', async function (assert) {
-    await visit('/');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');

--- a/tests/acceptance/not-found/accessibility-test.js
+++ b/tests/acceptance/not-found/accessibility-test.js
@@ -1,5 +1,6 @@
 import { visit } from '@ember/test-helpers';
 import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { timeout } from 'dummy/tests/helpers/resize-container';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -8,64 +9,60 @@ module('Acceptance | not-found', function (hooks) {
   setupApplicationTest(hooks);
   resetViewport(hooks);
 
-  test('@w1 @h1 Accessibility audit', async function (assert) {
+  hooks.beforeEach(async function () {
     await visit('/404');
+    await timeout();
+  });
+
+  test('@w1 @h1 Accessibility audit', async function (assert) {
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h1 Accessibility audit', async function (assert) {
-    await visit('/404');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h1 Accessibility audit', async function (assert) {
-    await visit('/404');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w1 @h2 Accessibility audit', async function (assert) {
-    await visit('/404');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h2 Accessibility audit', async function (assert) {
-    await visit('/404');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h2 Accessibility audit', async function (assert) {
-    await visit('/404');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w1 @h3 Accessibility audit', async function (assert) {
-    await visit('/404');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w2 @h3 Accessibility audit', async function (assert) {
-    await visit('/404');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');
   });
 
   test('@w3 @h3 Accessibility audit', async function (assert) {
-    await visit('/404');
     await a11yAudit();
 
     assert.ok(true, 'We passed Axe tests.');

--- a/tests/helpers/resize-container.js
+++ b/tests/helpers/resize-container.js
@@ -5,9 +5,9 @@ import { find } from '@ember/test-helpers';
 // This is a magic number. It is the time (in ms) for things to `settle`
 // after a resize. It is the time that we need to wait before assertions
 // that should pass will always pass.
-const RERENDER_TIME = 100;
+const RERENDER_TIME = 50;
 
-export function timeout(milliseconds) {
+export function timeout(milliseconds = RERENDER_TIME) {
   return new Promise((resolve) => {
     later(resolve, milliseconds);
   });
@@ -27,5 +27,5 @@ export default async function resizeContainer(width, height) {
   parentElement.style.width = `${width}px`;
   parentElement.style.height = `${height}px`;
 
-  await timeout(RERENDER_TIME);
+  await timeout();
 }

--- a/tests/integration/components/container-query/dataAttributePrefix-test.js
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.js
@@ -1,3 +1,4 @@
+import { set } from '@ember/object';
 import { render } from '@ember/test-helpers';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
 import resizeContainer from 'dummy/tests/helpers/resize-container';
@@ -336,7 +337,7 @@ module('Integration | Component | container-query', function (hooks) {
         </div>
       `);
 
-      this.set('dataAttributePrefix', 'cq2');
+      set(this, 'dataAttributePrefix', 'cq2');
     });
 
     test("The component doesn't update the data attributes", async function (assert) {

--- a/tests/integration/components/container-query/dataAttributePrefix-test.js
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.js
@@ -1,7 +1,7 @@
 import { set } from '@ember/object';
 import { render } from '@ember/test-helpers';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
-import resizeContainer from 'dummy/tests/helpers/resize-container';
+import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -46,6 +46,8 @@ module('Integration | Component | container-query', function (hooks) {
           </ContainerQuery>
         </div>
       `);
+
+      await timeout();
     });
 
     test('The component creates data attributes when it is rendered', async function (assert) {
@@ -142,6 +144,8 @@ module('Integration | Component | container-query', function (hooks) {
             </ContainerQuery>
           </div>
         `);
+
+        await timeout();
       });
 
       test('The component creates data attributes when it is rendered', async function (assert) {
@@ -239,6 +243,8 @@ module('Integration | Component | container-query', function (hooks) {
             </ContainerQuery>
           </div>
         `);
+
+        await timeout();
       });
 
       test('The component creates data attributes when it is rendered', async function (assert) {
@@ -336,6 +342,8 @@ module('Integration | Component | container-query', function (hooks) {
           </ContainerQuery>
         </div>
       `);
+
+      await timeout();
 
       set(this, 'dataAttributePrefix', 'cq2');
     });

--- a/tests/integration/components/container-query/debounce-test.js
+++ b/tests/integration/components/container-query/debounce-test.js
@@ -19,7 +19,7 @@ module('Integration | Component | container-query', function (hooks) {
         pass so that assertions that should pass will always pass.
 
         As a result, we can test `@debounce` only when the value is larger
-        than 100.
+        than `RERENDER_TIME`.
       */
       this.debounce = 250;
 

--- a/tests/integration/components/container-query/features-test.js
+++ b/tests/integration/components/container-query/features-test.js
@@ -1,3 +1,4 @@
+import { set } from '@ember/object';
 import { render } from '@ember/test-helpers';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
 import resizeContainer from 'dummy/tests/helpers/resize-container';
@@ -268,7 +269,7 @@ module('Integration | Component | container-query', function (hooks) {
         </div>
       `);
 
-      this.set('features', {
+      set(this, 'features', {
         large: {
           dimension: 'width',
           min: 600,

--- a/tests/integration/components/container-query/features-test.js
+++ b/tests/integration/components/container-query/features-test.js
@@ -1,7 +1,7 @@
 import { set } from '@ember/object';
 import { render } from '@ember/test-helpers';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
-import resizeContainer from 'dummy/tests/helpers/resize-container';
+import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -36,6 +36,8 @@ module('Integration | Component | container-query', function (hooks) {
           </ContainerQuery>
         </div>
       `);
+
+      await timeout();
     });
 
     test('The component renders', async function (assert) {
@@ -145,6 +147,8 @@ module('Integration | Component | container-query', function (hooks) {
           </ContainerQuery>
         </div>
       `);
+
+      await timeout();
     });
 
     test('The component renders', async function (assert) {
@@ -268,6 +272,8 @@ module('Integration | Component | container-query', function (hooks) {
           </ContainerQuery>
         </div>
       `);
+
+      await timeout();
 
       set(this, 'features', {
         large: {

--- a/tests/integration/components/container-query/splattributes-test.js
+++ b/tests/integration/components/container-query/splattributes-test.js
@@ -1,5 +1,6 @@
 import { render } from '@ember/test-helpers';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
+import { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -54,6 +55,8 @@ module('Integration | Component | container-query', function (hooks) {
           </ContainerQuery>
         </div>
       `);
+
+      await timeout();
 
       assert
         .dom('[data-test-container-query]')

--- a/tests/integration/components/container-query/tagName-test.js
+++ b/tests/integration/components/container-query/tagName-test.js
@@ -1,3 +1,4 @@
+import { set } from '@ember/object';
 import { render } from '@ember/test-helpers';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
 import resizeContainer from 'dummy/tests/helpers/resize-container';
@@ -180,7 +181,7 @@ module('Integration | Component | container-query', function (hooks) {
         </div>
       `);
 
-      this.set('tagName', 'article');
+      set(this, 'tagName', 'article');
     });
 
     test("The component doesn't update the tag", async function (assert) {

--- a/tests/integration/components/container-query/tagName-test.js
+++ b/tests/integration/components/container-query/tagName-test.js
@@ -1,7 +1,7 @@
 import { set } from '@ember/object';
 import { render } from '@ember/test-helpers';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
-import resizeContainer from 'dummy/tests/helpers/resize-container';
+import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -46,6 +46,8 @@ module('Integration | Component | container-query', function (hooks) {
           </ContainerQuery>
         </div>
       `);
+
+      await timeout();
     });
 
     test('The component has the <div> tag', async function (assert) {
@@ -112,6 +114,8 @@ module('Integration | Component | container-query', function (hooks) {
           </ContainerQuery>
         </div>
       `);
+
+      await timeout();
     });
 
     test('The component has the correct tag', async function (assert) {
@@ -180,6 +184,8 @@ module('Integration | Component | container-query', function (hooks) {
           </ContainerQuery>
         </div>
       `);
+
+      await timeout();
 
       set(this, 'tagName', 'article');
     });


### PR DESCRIPTION
## Background

In #76, I had applied `timeout` to two application tests so that assertions could always pass. However, I hadn't applied it to all rendering and application tests. At the time, I had thought it'd be better to apply `timeout` only when necessary and assume that Ember's intrinsic notion of settledness will take place.

In #74, I noticed that [a couple of rendering tests in CI were flaky](https://github.com/ijlee2/ember-container-query/pull/74#issuecomment-986521125). I merged the pull request regardless.


## Description

In this pull request, I decided to apply `timeout` to all rendering and application tests so that the environment in which tests run can be considered the same (excluding test window size). I decreased the timeout value from 100 ms to 50 ms, to match the value used by `ember-on-resize-modifier` in its tests.

https://github.com/PrecisionNutrition/ember-resize-kitchen-sink/blob/v0.4.5/packages/ember-on-resize-modifier/tests/utils.js#L3