### PR TITLE
Dropped support for 3.20 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   build-app:
     name: Build app for testing
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
   lint:
     name: Lint files and dependencies
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2
@@ -98,7 +98,7 @@ jobs:
             test-port: 7364
           - device: 'w3-h3'
             test-port: 7365
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2
@@ -152,7 +152,7 @@ jobs:
             test-port: 7364
           - device: 'w3-h3'
             test-port: 7365
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Check out a copy of the repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
         scenario:
           - 'ember-lts-3.20'
           - 'ember-lts-3.24'
+          - 'ember-lts-3.28'
           - 'ember-release'
           # - 'ember-beta'
           # - 'ember-canary'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,6 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          - 'ember-lts-3.20'
           - 'ember-lts-3.24'
           - 'ember-lts-3.28'
           - 'ember-release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
     needs: [build-app]
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         device:
           - 'w1-h1'

--- a/README.md
+++ b/README.md
@@ -286,8 +286,8 @@ For more examples, I encourage you to check out the code for my demo app. It is 
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.20 or above<sup>1</sup>
-* Ember CLI v3.20 or above
+* Ember.js v3.24 or above<sup>1</sup>
+* Ember CLI v3.24 or above
 * Node.js v12 or above
 * Modern browsers<sup>1</sup> (IE 11 won't be supported)
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,14 +8,6 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.20.5',
-          },
-        },
-      },
-      {
         name: 'ember-lts-3.24',
         npm: {
           devDependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -24,11 +24,18 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-release',
+        name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
             'ember-source': '~3.28.8',
-            // 'ember-source': await getChannelURL('release'),
+          },
+        },
+      },
+      {
+        name: 'ember-release',
+        npm: {
+          devDependencies: {
+            'ember-source': await getChannelURL('release'),
           },
         },
       },


### PR DESCRIPTION
## Description

Along with the release of Ember 4.0, Ember 3.28 has been promoted to LTS. I removed checks for Ember 3.20 LTS in continuous integration.


## References

- https://github.com/ember-learn/ember-website/pull/885