### PR TITLE
Updated Node version in CI to 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 4 * * MON'
 
 env:
-  NODE_VERSION: 14
+  NODE_VERSION: 16
   PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_number }}
   PERCY_PARALLEL_TOTAL: 9
 


### PR DESCRIPTION
## Description

Node 14 has been in maintenance mode. I'll update the Node version in CI to `16`.

![node-release-schedule](https://user-images.githubusercontent.com/16869656/171875843-5d537dad-a044-4b33-8d95-c0a7941da59d.svg)


## References

- https://nodejs.org/en/about/releases/