### PR TITLE
Updated GitHub actions to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
           node-version: ${{ env.NODE_VERSION }}
@@ -36,7 +36,7 @@ jobs:
         run: yarn build:test
 
       - name: Upload app
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist
@@ -48,10 +48,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
           node-version: ${{ env.NODE_VERSION }}
@@ -101,10 +101,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
           node-version: ${{ env.NODE_VERSION }}
@@ -113,7 +113,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Download app
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist
@@ -155,10 +155,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           cache: 'yarn'
           node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
## Notes

No breaking changes to my knowledge.


## References

- [`@actions/checkout`](https://github.com/actions/checkout/tree/v3.0.2)
- [`@actions/download-artifact`](https://github.com/actions/download-artifact/tree/v3.0.0)
- [`@actions/setup-node`](https://github.com/actions/setup-node/tree/v3.2.0)
- [`@actions/upload-artifact`](https://github.com/actions/upload-artifact/tree/v3.1.0)