### PR TITLE
Listed ember-test-selectors as a dependency

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,25 +3,11 @@
 const { maybeEmbroider } = require('@embroider/test-setup');
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-const isProduction = EmberAddon.env() === 'production';
-
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
-    autoImport: {
-      publicAssetURL: isProduction
-        ? 'https://ember-container-query.netlify.app/assets'
-        : undefined,
-    },
-
     fingerprint: {
-      enabled: isProduction,
       exclude: ['images/'],
-      prepend: 'https://ember-container-query.netlify.app/',
-    },
-
-    sourcemaps: {
-      enabled: true,
     },
   });
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,12 +3,25 @@
 const { maybeEmbroider } = require('@embroider/test-setup');
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
+const isProduction = EmberAddon.env() === 'production';
+
 module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
+    autoImport: {
+      publicAssetURL: isProduction
+        ? 'https://ember-container-query.netlify.app/assets'
+        : undefined,
+    },
+
     fingerprint: {
+      enabled: isProduction,
       exclude: ['images/'],
       prepend: 'https://ember-container-query.netlify.app/',
+    },
+
+    sourcemaps: {
+      enabled: true,
     },
   });
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "ember-cli-htmlbars": "^6.1.0",
     "ember-cli-typescript": "^5.1.0",
     "ember-element-helper": "^0.6.1",
-    "ember-on-resize-modifier": "^1.1.0"
+    "ember-on-resize-modifier": "^1.1.0",
+    "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -120,7 +121,6 @@
     "ember-source-channel-url": "^3.0.0",
     "ember-svg-jar": "^2.3.4",
     "ember-template-lint": "^4.10.1",
-    "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.0.0",
     "ember-try": "^2.0.0",
     "eslint": "^8.19.0",


### PR DESCRIPTION
## Description

According to the [`ember-test-selectors` documentation](https://github.com/simplabs/ember-test-selectors/tree/v6.0.0#usage-in-ember-addons):

> If you want to use ember-test-selectors in an addon make sure that it appears in the `dependencies` section of the `package.json` file, not in the `devDependencies`. This ensures that the selectors are also stripped correctly even if the app that uses the addon does not use ember-test-selectors itself.

I also realized that the deploy preview in a PR wouldn't work due to `fingerprint.prepend` taking on a constant value. I fixed the configuration in this pull request.


## Screenshots

Before:

The production site includes the data attribute `data-test-container-query`.

<img width="1440" alt="" src="https://user-images.githubusercontent.com/16869656/179690025-7ee852cc-85be-4093-9ea2-33f4b496e68a.png">


After:

The deploy preview site no longer includes the data attribute `data-test-container-query`.

<img width="1440" alt="" src="https://user-images.githubusercontent.com/16869656/179690010-3259012d-098a-4567-964b-9d8668a8630a.png">
