### PR TITLE
Replaced @ember/render-modifiers with ember-modifier

### DIFF
--- a/addon/components/container-query.hbs
+++ b/addon/components/container-query.hbs
@@ -6,16 +6,13 @@
       dataAttributePrefix=@dataAttributePrefix
       debounce=@debounce
       features=@features
+      onQuery=this.updateState
     }}
     ...attributes
   >
     {{yield (hash
+      dimensions=this.dimensions
       features=this.queryResults
-      dimensions=(hash
-        aspectRatio=this.aspectRatio
-        height=this.height
-        width=this.width
-      )
     )}}
   </Tag>
 {{/let}}

--- a/addon/components/container-query.hbs
+++ b/addon/components/container-query.hbs
@@ -2,8 +2,7 @@
   <Tag
     class="container-query"
     data-test-container-query
-    {{did-insert this.queryContainer}}
-    {{on-resize this.onResize}}
+    {{container-query}}
     ...attributes
   >
     {{yield (hash

--- a/addon/components/container-query.hbs
+++ b/addon/components/container-query.hbs
@@ -2,7 +2,11 @@
   <Tag
     class="container-query"
     data-test-container-query
-    {{container-query}}
+    {{container-query
+      dataAttributePrefix=@dataAttributePrefix
+      debounce=@debounce
+      features=@features
+    }}
     ...attributes
   >
     {{yield (hash

--- a/addon/components/container-query.ts
+++ b/addon/components/container-query.ts
@@ -48,15 +48,8 @@ export default class ContainerQueryComponent extends Component<ContainerQueryCom
   }
 
   @action queryContainer(element: Element): void {
-    this.measureDimensions(element);
     this.evaluateQueries();
     this.setDataAttributes(element);
-  }
-
-  measureDimensions(element: Element): void {
-    this.height = element.clientHeight;
-    this.width = element.clientWidth;
-    this.aspectRatio = this.width / this.height;
   }
 
   evaluateQueries(): void {

--- a/addon/components/container-query.ts
+++ b/addon/components/container-query.ts
@@ -2,11 +2,10 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { debounce } from '@ember/runloop';
-import type { Features } from 'ember-container-query/modifiers/container-query';
-
-type QueryResults = {
-  [featureName: string]: boolean;
-};
+import type {
+  Features,
+  QueryResults,
+} from 'ember-container-query/modifiers/container-query';
 
 interface ContainerQueryComponentArgs {
   dataAttributePrefix?: string;
@@ -48,21 +47,7 @@ export default class ContainerQueryComponent extends Component<ContainerQueryCom
   }
 
   @action queryContainer(element: Element): void {
-    this.evaluateQueries();
     this.setDataAttributes(element);
-  }
-
-  evaluateQueries(): void {
-    const queryResults = {} as QueryResults;
-
-    for (const [featureName, metadata] of Object.entries(this.features)) {
-      const { dimension, min, max } = metadata;
-      const value = this[dimension]!;
-
-      queryResults[featureName] = min <= value && value < max;
-    }
-
-    this.queryResults = queryResults;
   }
 
   setDataAttributes(element: Element): void {

--- a/addon/components/container-query.ts
+++ b/addon/components/container-query.ts
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { debounce } from '@ember/runloop';
 import type {
   Dimensions,
   Features,
@@ -19,34 +18,8 @@ export default class ContainerQueryComponent extends Component<ContainerQueryCom
   @tracked dimensions?: Dimensions;
   @tracked queryResults?: QueryResults;
 
-  get features(): Features {
-    return this.args.features ?? {};
-  }
-
-  get dataAttributePrefix(): string {
-    return this.args.dataAttributePrefix ?? 'container-query';
-  }
-
-  get debounce(): number {
-    return this.args.debounce ?? 0;
-  }
-
   // The dynamic tag is restricted to be immutable
   tagName = this.args.tagName ?? 'div';
-
-  @action onResize(resizeObserverEntry: ResizeObserverEntry): void {
-    const element = resizeObserverEntry.target;
-
-    if (this.debounce > 0) {
-      debounce(this, this.queryContainer, element, this.debounce);
-      return;
-    }
-
-    this.queryContainer(element);
-  }
-
-  /* eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars */
-  @action queryContainer(element: Element): void {}
 
   @action updateState({
     dimensions,

--- a/addon/components/container-query.ts
+++ b/addon/components/container-query.ts
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { debounce } from '@ember/runloop';
 import type {
+  Dimensions,
   Features,
   QueryResults,
 } from 'ember-container-query/modifiers/container-query';
@@ -15,10 +16,8 @@ interface ContainerQueryComponentArgs {
 }
 
 export default class ContainerQueryComponent extends Component<ContainerQueryComponentArgs> {
-  @tracked queryResults = {} as QueryResults;
-  @tracked aspectRatio?: number;
-  @tracked height?: number;
-  @tracked width?: number;
+  @tracked dimensions?: Dimensions;
+  @tracked queryResults?: QueryResults;
 
   get features(): Features {
     return this.args.features ?? {};
@@ -48,4 +47,15 @@ export default class ContainerQueryComponent extends Component<ContainerQueryCom
 
   /* eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars */
   @action queryContainer(element: Element): void {}
+
+  @action updateState({
+    dimensions,
+    queryResults,
+  }: {
+    dimensions: Dimensions;
+    queryResults: QueryResults;
+  }): void {
+    this.dimensions = dimensions;
+    this.queryResults = queryResults;
+  }
 }

--- a/addon/components/container-query.ts
+++ b/addon/components/container-query.ts
@@ -2,16 +2,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { debounce } from '@ember/runloop';
-
-type Metadata = {
-  dimension: 'aspectRatio' | 'height' | 'width';
-  max: number;
-  min: number;
-};
-
-type Features = {
-  [featureName: string]: Metadata;
-};
+import type { Features } from 'ember-container-query/modifiers/container-query';
 
 type QueryResults = {
   [featureName: string]: boolean;

--- a/addon/components/container-query.ts
+++ b/addon/components/container-query.ts
@@ -46,29 +46,6 @@ export default class ContainerQueryComponent extends Component<ContainerQueryCom
     this.queryContainer(element);
   }
 
-  @action queryContainer(element: Element): void {
-    this.setDataAttributes(element);
-  }
-
-  setDataAttributes(element: Element): void {
-    const prefix = this.dataAttributePrefix;
-
-    for (const [featureName, meetsFeature] of Object.entries(
-      this.queryResults
-    )) {
-      let attributeName;
-
-      if (prefix) {
-        attributeName = `data-${prefix}-${featureName}`;
-      } else {
-        attributeName = `data-${featureName}`;
-      }
-
-      if (meetsFeature) {
-        element.setAttribute(attributeName, '');
-      } else {
-        element.removeAttribute(attributeName);
-      }
-    }
-  }
+  /* eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars */
+  @action queryContainer(element: Element): void {}
 }

--- a/addon/helpers/cq-aspect-ratio.ts
+++ b/addon/helpers/cq-aspect-ratio.ts
@@ -1,10 +1,5 @@
 import { helper } from '@ember/component/helper';
-
-type Metadata = {
-  dimension: 'aspectRatio' | 'height' | 'width';
-  max: number;
-  min: number;
-};
+import type { Metadata } from 'ember-container-query/modifiers/container-query';
 
 function cqAspectRatio(
   positional: unknown[],

--- a/addon/helpers/cq-height.ts
+++ b/addon/helpers/cq-height.ts
@@ -1,10 +1,5 @@
 import { helper } from '@ember/component/helper';
-
-type Metadata = {
-  dimension: 'aspectRatio' | 'height' | 'width';
-  max: number;
-  min: number;
-};
+import type { Metadata } from 'ember-container-query/modifiers/container-query';
 
 function cqHeight(
   positional: unknown[],

--- a/addon/helpers/cq-width.ts
+++ b/addon/helpers/cq-width.ts
@@ -1,10 +1,5 @@
 import { helper } from '@ember/component/helper';
-
-type Metadata = {
-  dimension: 'aspectRatio' | 'height' | 'width';
-  max: number;
-  min: number;
-};
+import type { Metadata } from 'ember-container-query/modifiers/container-query';
 
 function cqWidth(
   positional: unknown[],

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -55,9 +55,7 @@ export default class ContainerQueryModifier extends Modifier<ContainerQueryModif
   private queryContainer(element: Element): void {
     this.measureDimensions(element);
     this.evaluateQueries();
-
-    console.log(this.dimensions);
-    console.log(this.queryResults);
+    this.setDataAttributes(element);
   }
 
   private measureDimensions(element: Element): void {
@@ -82,5 +80,27 @@ export default class ContainerQueryModifier extends Modifier<ContainerQueryModif
     }
 
     this.queryResults = queryResults;
+  }
+
+  private setDataAttributes(element: Element): void {
+    const prefix = this.dataAttributePrefix;
+
+    for (const [featureName, meetsFeature] of Object.entries(
+      this.queryResults
+    )) {
+      let attributeName;
+
+      if (prefix) {
+        attributeName = `data-${prefix}-${featureName}`;
+      } else {
+        attributeName = `data-${featureName}`;
+      }
+
+      if (meetsFeature) {
+        element.setAttribute(attributeName, '');
+      } else {
+        element.removeAttribute(attributeName);
+      }
+    }
   }
 }

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -1,0 +1,19 @@
+import Modifier from 'ember-modifier';
+
+interface ContainerQueryModifierSignature {
+  Args: {
+    Named: {};
+    Positional: [];
+  };
+  Element: Element;
+}
+
+export default class ContainerQueryModifier extends Modifier<ContainerQueryModifierSignature> {
+  modify(element: Element): void {
+    this.queryContainer(element);
+  }
+
+  private queryContainer(element: Element): void {
+    console.log(element);
+  }
+}

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -10,6 +10,12 @@ export type Features = {
   [featureName: string]: Metadata;
 };
 
+export type Dimensions = {
+  aspectRatio: number;
+  height: number;
+  width: number;
+};
+
 interface ContainerQueryModifierSignature {
   Args: {
     Named: {
@@ -23,6 +29,8 @@ interface ContainerQueryModifierSignature {
 }
 
 export default class ContainerQueryModifier extends Modifier<ContainerQueryModifierSignature> {
+  dimensions!: Dimensions;
+
   get dataAttributePrefix(): string {
     return this.args.named.dataAttributePrefix ?? 'container-query';
   }
@@ -40,9 +48,19 @@ export default class ContainerQueryModifier extends Modifier<ContainerQueryModif
   }
 
   private queryContainer(element: Element): void {
-    const { dataAttributePrefix, debounce, features } = this;
+    this.measureDimensions(element);
 
-    console.log(element);
-    console.table({ dataAttributePrefix, debounce, features });
+    console.log(this.dimensions);
+  }
+
+  private measureDimensions(element: Element): void {
+    const height = element.clientHeight;
+    const width = element.clientWidth;
+
+    this.dimensions = {
+      aspectRatio: width / height,
+      height,
+      width,
+    };
   }
 }

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -1,19 +1,48 @@
 import Modifier from 'ember-modifier';
 
+export type Metadata = {
+  dimension: 'aspectRatio' | 'height' | 'width';
+  max: number;
+  min: number;
+};
+
+export type Features = {
+  [featureName: string]: Metadata;
+};
+
 interface ContainerQueryModifierSignature {
   Args: {
-    Named: {};
+    Named: {
+      dataAttributePrefix?: string;
+      debounce?: number;
+      features?: Features;
+    };
     Positional: [];
   };
   Element: Element;
 }
 
 export default class ContainerQueryModifier extends Modifier<ContainerQueryModifierSignature> {
+  get dataAttributePrefix(): string {
+    return this.args.named.dataAttributePrefix ?? 'container-query';
+  }
+
+  get debounce(): number {
+    return this.args.named.debounce ?? 0;
+  }
+
+  get features(): Features {
+    return this.args.named.features ?? {};
+  }
+
   modify(element: Element): void {
     this.queryContainer(element);
   }
 
   private queryContainer(element: Element): void {
+    const { dataAttributePrefix, debounce, features } = this;
+
     console.log(element);
+    console.table({ dataAttributePrefix, debounce, features });
   }
 }

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -26,6 +26,13 @@ interface ContainerQueryModifierSignature {
       dataAttributePrefix?: string;
       debounce?: number;
       features?: Features;
+      onQuery?: ({
+        dimensions,
+        queryResults,
+      }: {
+        dimensions: Dimensions;
+        queryResults: QueryResults;
+      }) => void;
     };
     Positional: [];
   };
@@ -56,6 +63,11 @@ export default class ContainerQueryModifier extends Modifier<ContainerQueryModif
     this.measureDimensions(element);
     this.evaluateQueries();
     this.setDataAttributes(element);
+
+    this.args.named.onQuery?.({
+      dimensions: this.dimensions,
+      queryResults: this.queryResults,
+    });
   }
 
   private measureDimensions(element: Element): void {

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -16,6 +16,10 @@ export type Dimensions = {
   width: number;
 };
 
+export type QueryResults = {
+  [featureName: string]: boolean;
+};
+
 interface ContainerQueryModifierSignature {
   Args: {
     Named: {
@@ -30,6 +34,7 @@ interface ContainerQueryModifierSignature {
 
 export default class ContainerQueryModifier extends Modifier<ContainerQueryModifierSignature> {
   dimensions!: Dimensions;
+  queryResults!: QueryResults;
 
   get dataAttributePrefix(): string {
     return this.args.named.dataAttributePrefix ?? 'container-query';
@@ -49,8 +54,10 @@ export default class ContainerQueryModifier extends Modifier<ContainerQueryModif
 
   private queryContainer(element: Element): void {
     this.measureDimensions(element);
+    this.evaluateQueries();
 
     console.log(this.dimensions);
+    console.log(this.queryResults);
   }
 
   private measureDimensions(element: Element): void {
@@ -62,5 +69,18 @@ export default class ContainerQueryModifier extends Modifier<ContainerQueryModif
       height,
       width,
     };
+  }
+
+  private evaluateQueries(): void {
+    const queryResults = {} as QueryResults;
+
+    for (const [featureName, metadata] of Object.entries(this.features)) {
+      const { dimension, min, max } = metadata;
+      const value = this.dimensions[dimension];
+
+      queryResults[featureName] = min <= value && value < max;
+    }
+
+    this.queryResults = queryResults;
   }
 }

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -51,6 +51,7 @@ export default class ContainerQueryModifier extends Modifier<ContainerQueryModif
   dimensions!: Dimensions;
   queryResults!: QueryResults;
 
+  private _dataAttributes: string[] = [];
   private _element?: Element;
 
   get dataAttributePrefix(): string {
@@ -99,6 +100,7 @@ export default class ContainerQueryModifier extends Modifier<ContainerQueryModif
   private queryContainer(element: Element): void {
     this.measureDimensions(element);
     this.evaluateQueries();
+    this.resetDataAttributes(element);
     this.setDataAttributes(element);
 
     this.args.named.onQuery?.({
@@ -131,25 +133,31 @@ export default class ContainerQueryModifier extends Modifier<ContainerQueryModif
     this.queryResults = queryResults;
   }
 
+  private resetDataAttributes(element: Element): void {
+    this._dataAttributes.forEach((dataAttribute) => {
+      element.removeAttribute(dataAttribute);
+    });
+
+    this._dataAttributes = [];
+  }
+
   private setDataAttributes(element: Element): void {
     const prefix = this.dataAttributePrefix;
 
     for (const [featureName, meetsFeature] of Object.entries(
       this.queryResults
     )) {
-      let attributeName;
-
-      if (prefix) {
-        attributeName = `data-${prefix}-${featureName}`;
-      } else {
-        attributeName = `data-${featureName}`;
+      if (!meetsFeature) {
+        continue;
       }
 
-      if (meetsFeature) {
-        element.setAttribute(attributeName, '');
-      } else {
-        element.removeAttribute(attributeName);
-      }
+      const dataAttribute = prefix
+        ? `data-${prefix}-${featureName}`
+        : `data-${featureName}`;
+
+      element.setAttribute(dataAttribute, '');
+
+      this._dataAttributes.push(dataAttribute);
     }
   }
 }

--- a/app/modifiers/container-query.js
+++ b/app/modifiers/container-query.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-container-query/modifiers/container-query';

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "ember-cli-htmlbars": "^6.1.0",
     "ember-cli-typescript": "^5.1.0",
     "ember-element-helper": "^0.6.1",
-    "ember-on-resize-modifier": "^1.1.0",
     "ember-modifier": "^3.2.7",
+    "ember-resize-observer-service": "^1.1.0",
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
@@ -77,6 +77,7 @@
     "@types/ember__component": "^4.0.8",
     "@types/ember__controller": "^4.0.0",
     "@types/ember__debug": "^4.0.1",
+    "@types/ember__destroyable": "^4.0.0",
     "@types/ember__engine": "^4.0.0",
     "@types/ember__error": "^4.0.0",
     "@types/ember__object": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     }
   },
   "dependencies": {
-    "@ember/render-modifiers": "^2.0.4",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.0",
     "ember-cli-typescript": "^5.1.0",
     "ember-element-helper": "^0.6.1",
     "ember-on-resize-modifier": "^1.1.0",
+    "ember-modifier": "^3.2.7",
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {

--- a/tests/dummy/app/components/tracks/list.hbs
+++ b/tests/dummy/app/components/tracks/list.hbs
@@ -2,8 +2,10 @@
   data-test-list="Tracks"
   data-css-grid="{{this.numRows}} x {{this.numColumns}}"
   local-class="list"
-  {{did-insert this.updateCssForRows}}
-  {{did-update this.updateCssForRows @tracks @numColumns}}
+  {{dynamic-css-grid
+    numColumns=this.numColumns
+    numRows=this.numRows
+  }}
 >
   {{#each @tracks as |track index|}}
     <li

--- a/tests/dummy/app/components/tracks/list.ts
+++ b/tests/dummy/app/components/tracks/list.ts
@@ -1,4 +1,3 @@
-import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import type { Track } from 'dummy/data/album';
 
@@ -14,10 +13,5 @@ export default class TracksListComponent extends Component<TracksListComponentAr
 
   get numRows(): number {
     return Math.ceil(this.args.tracks.length / this.numColumns);
-  }
-
-  @action updateCssForRows(element: HTMLElement): void {
-    element.style.gridTemplateColumns = `repeat(${this.numColumns}, minmax(0, 1fr))`;
-    element.style.gridTemplateRows = `repeat(${this.numRows}, 1fr)`;
   }
 }

--- a/tests/dummy/app/components/widgets/widget-2/captions.hbs
+++ b/tests/dummy/app/components/widgets/widget-2/captions.hbs
@@ -5,11 +5,7 @@
   }}
   as |CQ|
 >
-  <div
-    local-class="container {{unless CQ.features.tall "flat"}}"
-    {{did-insert this.showSummary}}
-    {{did-update this.showSummary this.summaries}}
-  >
+  <div local-class="container {{unless CQ.features.tall "flat"}}">
     {{#if this.summary}}
       <div local-class="summary {{if CQ.features.large "horizontal-layout"}}" tabindex="0">
         <h3

--- a/tests/dummy/app/components/widgets/widget-2/captions.ts
+++ b/tests/dummy/app/components/widgets/widget-2/captions.ts
@@ -10,7 +10,6 @@ interface WidgetsWidget2CaptionsComponentArgs {
 }
 
 export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsComponentArgs> {
-  @tracked summary?: Summary;
   @tracked currentIndex = 0;
 
   get styleForMarker(): SafeString {
@@ -19,6 +18,10 @@ export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWi
     }
 
     return htmlSafe(`color: ${this.summary.markerColor};`);
+  }
+
+  get summary(): Summary | undefined {
+    return this.summaries[this.currentIndex];
   }
 
   get summaries(): Array<Summary> {
@@ -33,17 +36,11 @@ export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWi
     return this.currentIndex < this.summaries.length - 1;
   }
 
-  @action showSummary(): void {
-    this.summary = this.summaries[0];
-    this.currentIndex = 0;
-  }
-
   @action showNextSummary(increment = 1): void {
     const numSummaries = this.summaries.length;
     const nextIndex =
       (this.currentIndex + increment + numSummaries) % numSummaries;
 
-    this.summary = this.summaries[nextIndex];
     this.currentIndex = nextIndex;
   }
 }

--- a/tests/dummy/app/components/widgets/widget-2/stacked-chart.hbs
+++ b/tests/dummy/app/components/widgets/widget-2/stacked-chart.hbs
@@ -1,8 +1,6 @@
 <div
   local-class="svg-container"
-  {{did-insert this.refreshChart}}
-  {{did-update this.drawChart this.data}}
-  {{on-resize this.onResize}}
+  {{draw-chart data=@data}}
 >
   <svg local-class="svg">
   </svg>

--- a/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
+++ b/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.hbs
@@ -5,15 +5,19 @@
   >
     <div
       local-class="image-container"
-      {{did-update (fn this.setImageSource CQ.dimensions) CQ.dimensions}}
+      {{find-best-fitting-image
+        dimensions=CQ.dimensions
+        images=@images
+        onQuery=this.setImageSource
+      }}
     >
-      {{#if this.src}}
+      {{#if this.imageSource}}
         <img
           alt=""
           data-test-image="Concert"
           local-class="image"
           role="presentation"
-          src={{this.src}}
+          src={{this.imageSource}}
         />
       {{/if}}
     </div>

--- a/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,8 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { findBestFittingImage } from 'dummy/utils/components/widgets/widget-3';
-import type { ContainerDimensions } from 'dummy/utils/components/widgets/widget-3';
 import type { Image } from 'dummy/data/concert';
 
 interface WidgetsWidget3TourScheduleResponsiveImageComponentArgs {
@@ -10,21 +8,9 @@ interface WidgetsWidget3TourScheduleResponsiveImageComponentArgs {
 }
 
 export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentArgs> {
-  @tracked src?: string;
+  @tracked imageSource?: string;
 
-  @action setImageSource(dimensions: ContainerDimensions): void {
-    /*
-      I added a guard just in case <ContainerQuery> has yet to compute
-      the container's width and height. We can check the aspect ratio
-      to determine if all 3 dimensions are defined.
-
-      In practice--at least, when I ran the app locally--all dimensions
-      were defined by the time `setImageSource` was called.
-    */
-    if (dimensions.aspectRatio === undefined) {
-      return;
-    }
-
-    this.src = findBestFittingImage(this.args.images, dimensions);
+  @action setImageSource(imageSource?: string): void {
+    this.imageSource = imageSource;
   }
 }

--- a/tests/dummy/app/modifiers/dynamic-css-grid.ts
+++ b/tests/dummy/app/modifiers/dynamic-css-grid.ts
@@ -1,0 +1,26 @@
+import { modifier, NamedArgs, PositionalArgs } from 'ember-modifier';
+
+interface DynamicCssGridModifierSignature {
+  Args: {
+    Named: {
+      numColumns: number;
+      numRows: number;
+    };
+    Positional: [];
+  };
+  Element: Element;
+}
+
+export default modifier(function dynamicCssGrid(
+  element: Element,
+  _: PositionalArgs<DynamicCssGridModifierSignature>,
+  named: NamedArgs<DynamicCssGridModifierSignature>
+): void {
+  const { numColumns, numRows } = named;
+
+  (
+    element as HTMLElement
+  ).style.gridTemplateColumns = `repeat(${numColumns}, minmax(0, 1fr))`;
+
+  (element as HTMLElement).style.gridTemplateRows = `repeat(${numRows}, 1fr)`;
+});

--- a/tests/dummy/app/modifiers/find-best-fitting-image.ts
+++ b/tests/dummy/app/modifiers/find-best-fitting-image.ts
@@ -1,0 +1,32 @@
+import type { Image } from 'dummy/data/concert';
+import { findBestFittingImage as _findBestFittingImage } from 'dummy/utils/components/widgets/widget-3';
+import type { Dimensions } from 'ember-container-query/modifiers/container-query';
+import { modifier, NamedArgs, PositionalArgs } from 'ember-modifier';
+
+interface FindBestFittingImageModifierSignature {
+  Args: {
+    Named: {
+      dimensions?: Dimensions;
+      images?: Array<Image>;
+      onQuery: (imageSource?: string) => void;
+    };
+    Positional: [];
+  };
+  Element: Element;
+}
+
+export default modifier(function findBestFittingImage(
+  element: Element,
+  _: PositionalArgs<FindBestFittingImageModifierSignature>,
+  named: NamedArgs<FindBestFittingImageModifierSignature>
+) {
+  const { dimensions, images, onQuery } = named;
+
+  if (!dimensions || !images) {
+    onQuery();
+    return;
+  }
+
+  const imageSource = _findBestFittingImage(images, dimensions);
+  onQuery(imageSource);
+});

--- a/tests/integration/components/container-query/dataAttributePrefix-test.ts
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.ts
@@ -358,7 +358,8 @@ module('Integration | Component | container-query', function (hooks) {
       set(this, 'dataAttributePrefix', 'cq2');
     });
 
-    test("The component doesn't update the data attributes", async function (assert: CustomAssert) {
+    test('The component updates the data attributes', async function (assert: CustomAssert) {
+      /* TODO: Remove old data attributes */
       assert.areDataAttributesCorrect!({
         'data-cq1-small': '',
         'data-cq1-medium': undefined,
@@ -371,13 +372,13 @@ module('Integration | Component | container-query', function (hooks) {
       });
 
       assert.areDataAttributesCorrect!({
-        'data-cq2-small': undefined,
+        'data-cq2-small': '',
         'data-cq2-medium': undefined,
         'data-cq2-large': undefined,
         'data-cq2-short': undefined,
-        'data-cq2-tall': undefined,
-        'data-cq2-ratio-type-A': undefined,
-        'data-cq2-ratio-type-B': undefined,
+        'data-cq2-tall': '',
+        'data-cq2-ratio-type-A': '',
+        'data-cq2-ratio-type-B': '',
         'data-cq2-ratio-type-C': undefined,
       });
     });
@@ -385,6 +386,7 @@ module('Integration | Component | container-query', function (hooks) {
     test('The component updates the data attributes when it is resized', async function (assert: CustomAssert) {
       await resizeContainer(500, 300);
 
+      /* TODO: Remove old data attributes */
       assert.areDataAttributesCorrect!({
         'data-cq1-small': '',
         'data-cq1-medium': undefined,
@@ -409,6 +411,7 @@ module('Integration | Component | container-query', function (hooks) {
 
       await resizeContainer(800, 400);
 
+      /* TODO: Remove old data attributes */
       assert.areDataAttributesCorrect!({
         'data-cq1-small': '',
         'data-cq1-medium': undefined,
@@ -433,6 +436,7 @@ module('Integration | Component | container-query', function (hooks) {
 
       await resizeContainer(1000, 600);
 
+      /* TODO: Remove old data attributes */
       assert.areDataAttributesCorrect!({
         'data-cq1-small': '',
         'data-cq1-medium': undefined,

--- a/tests/integration/components/container-query/dataAttributePrefix-test.ts
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.ts
@@ -359,15 +359,14 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component updates the data attributes', async function (assert: CustomAssert) {
-      /* TODO: Remove old data attributes */
       assert.areDataAttributesCorrect!({
-        'data-cq1-small': '',
+        'data-cq1-small': undefined,
         'data-cq1-medium': undefined,
         'data-cq1-large': undefined,
         'data-cq1-short': undefined,
-        'data-cq1-tall': '',
-        'data-cq1-ratio-type-A': '',
-        'data-cq1-ratio-type-B': '',
+        'data-cq1-tall': undefined,
+        'data-cq1-ratio-type-A': undefined,
+        'data-cq1-ratio-type-B': undefined,
         'data-cq1-ratio-type-C': undefined,
       });
 
@@ -386,15 +385,14 @@ module('Integration | Component | container-query', function (hooks) {
     test('The component updates the data attributes when it is resized', async function (assert: CustomAssert) {
       await resizeContainer(500, 300);
 
-      /* TODO: Remove old data attributes */
       assert.areDataAttributesCorrect!({
-        'data-cq1-small': '',
+        'data-cq1-small': undefined,
         'data-cq1-medium': undefined,
         'data-cq1-large': undefined,
         'data-cq1-short': undefined,
-        'data-cq1-tall': '',
-        'data-cq1-ratio-type-A': '',
-        'data-cq1-ratio-type-B': '',
+        'data-cq1-tall': undefined,
+        'data-cq1-ratio-type-A': undefined,
+        'data-cq1-ratio-type-B': undefined,
         'data-cq1-ratio-type-C': undefined,
       });
 
@@ -411,15 +409,14 @@ module('Integration | Component | container-query', function (hooks) {
 
       await resizeContainer(800, 400);
 
-      /* TODO: Remove old data attributes */
       assert.areDataAttributesCorrect!({
-        'data-cq1-small': '',
+        'data-cq1-small': undefined,
         'data-cq1-medium': undefined,
         'data-cq1-large': undefined,
         'data-cq1-short': undefined,
-        'data-cq1-tall': '',
-        'data-cq1-ratio-type-A': '',
-        'data-cq1-ratio-type-B': '',
+        'data-cq1-tall': undefined,
+        'data-cq1-ratio-type-A': undefined,
+        'data-cq1-ratio-type-B': undefined,
         'data-cq1-ratio-type-C': undefined,
       });
 
@@ -436,15 +433,14 @@ module('Integration | Component | container-query', function (hooks) {
 
       await resizeContainer(1000, 600);
 
-      /* TODO: Remove old data attributes */
       assert.areDataAttributesCorrect!({
-        'data-cq1-small': '',
+        'data-cq1-small': undefined,
         'data-cq1-medium': undefined,
         'data-cq1-large': undefined,
         'data-cq1-short': undefined,
-        'data-cq1-tall': '',
-        'data-cq1-ratio-type-A': '',
-        'data-cq1-ratio-type-B': '',
+        'data-cq1-tall': undefined,
+        'data-cq1-ratio-type-A': undefined,
+        'data-cq1-ratio-type-B': undefined,
         'data-cq1-ratio-type-C': undefined,
       });
 

--- a/tests/integration/components/container-query/features-test.ts
+++ b/tests/integration/components/container-query/features-test.ts
@@ -314,19 +314,19 @@ module('Integration | Component | container-query', function (hooks) {
       });
     });
 
-    test("The component doesn't update the features", async function (assert: CustomAssert) {
+    test('The component updates the features', async function (assert: CustomAssert) {
       assert.areFeaturesCorrect!({
-        small: true,
-        medium: false,
-        short: false,
-        'ratio-type-C': false,
+        small: undefined,
+        medium: undefined,
+        short: undefined,
+        'ratio-type-C': undefined,
       });
 
       assert.areFeaturesCorrect!({
-        large: undefined,
-        tall: undefined,
-        'ratio-type-A': undefined,
-        'ratio-type-B': undefined,
+        large: false,
+        tall: true,
+        'ratio-type-A': true,
+        'ratio-type-B': true,
       });
     });
 

--- a/tests/integration/modifiers/container-query-test.ts
+++ b/tests/integration/modifiers/container-query-test.ts
@@ -1,0 +1,26 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Modifier | container-query', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('We can call the modifier without passing arguments', async function (assert) {
+    await render(hbs`
+      {{!-- template-lint-disable no-inline-styles --}}
+      <div
+        data-test-parent-element
+        style="width: 250px; height: 500px;"
+      >
+        <div
+          style="width: 100%; height: 100%;"
+          {{container-query}}
+        >
+        </div>
+      </div>
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/modifiers/draw-chart-test.ts
+++ b/tests/integration/modifiers/draw-chart-test.ts
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifier | draw-chart', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('We can draw a chart', async function (assert) {
+    await render(hbs`
+      <div {{draw-chart}}>
+        <svg></svg>
+      </div>
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/modifiers/dynamic-css-grid-test.ts
+++ b/tests/integration/modifiers/dynamic-css-grid-test.ts
@@ -1,0 +1,23 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+module('Integration | Modifier | dynamic-css-grid', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('We can dynamically style the CSS grid', async function (assert) {
+    await render(hbs`
+      <div
+        data-test-list="Tracks"
+        {{dynamic-css-grid
+          numColumns=3
+          numRows=4
+        }}
+      >
+      </div>
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/modifiers/find-best-fitting-image-test.ts
+++ b/tests/integration/modifiers/find-best-fitting-image-test.ts
@@ -1,0 +1,29 @@
+import { render } from '@ember/test-helpers';
+import type { TestContext as BaseTestContext } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+interface TestContext extends BaseTestContext {
+  noOp: (imageSource?: string) => void;
+}
+
+module('Integration | Modifier | find-best-fitting-image', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('We can find the best-fitting image', async function (this: TestContext, assert) {
+    /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+    this.noOp = () => {};
+
+    await render(hbs`
+      <div
+        {{find-best-fitting-image
+          onQuery=this.noOp
+        }}
+      >
+      </div>
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,15 +1013,6 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
-"@ember/render-modifiers@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-2.0.4.tgz#0ac7af647cb736076dbfcd54ca71e090cd329d71"
-  integrity sha512-Zh/fo5VUmVzYHkHVvzWVjJ1RjFUxA2jH0zCp2+DQa80Bf3DUXauiEByxU22UkN4LFT55DBFttC0xCQSJG3WTsg==
-  dependencies:
-    "@embroider/macros" "^1.0.0"
-    ember-cli-babel "^7.26.11"
-    ember-modifier-manager-polyfill "^1.2.0"
-
 "@ember/test-helpers@^2.8.1":
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.8.1.tgz#20f2e30d48172c2ff713e1db7fbec5352f918d4e"
@@ -5449,7 +5440,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.1:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.10.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.6, ember-cli-babel@^7.26.8, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.4, ember-cli-babel@^7.26.6, ember-cli-babel@^7.26.8, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -5699,14 +5690,6 @@ ember-cli-typescript@^5.0.0, ember-cli-typescript@^5.1.0:
     stagehand "^1.0.0"
     walk-sync "^2.2.0"
 
-ember-cli-version-checker@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
-  integrity sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==
-  dependencies:
-    resolve "^1.3.3"
-    semver "^5.3.0"
-
 ember-cli-version-checker@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz#7c9b4f5ff30fdebcd480b1c06c4de43bb51c522c"
@@ -5831,7 +5814,7 @@ ember-cli@~4.5.0:
     workerpool "^6.2.0"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.5:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz#b8363b1d5b8725afa9a4fe2b2986ac28626c6f23"
   integrity sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==
@@ -5891,15 +5874,6 @@ ember-load-initializers@^2.1.2:
   dependencies:
     ember-cli-babel "^7.13.0"
     ember-cli-typescript "^2.0.2"
-
-ember-modifier-manager-polyfill@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
-  integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
-  dependencies:
-    ember-cli-babel "^7.10.0"
-    ember-cli-version-checker "^2.1.2"
-    ember-compatibility-helpers "^1.2.0"
 
 ember-modifier@^3.2.7:
   version "3.2.7"
@@ -11280,7 +11254,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1738,6 +1738,11 @@
     "@types/ember__debug" "*"
     "@types/ember__object" "*"
 
+"@types/ember__destroyable@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/ember__destroyable/-/ember__destroyable-4.0.0.tgz#997af44863323979796fbd153e9ad76498defb33"
+  integrity sha512-QxyRhCOlQmc056tbWvHOQZ7vIjlFOFYMOU82P3pcCFfxyi55+NRhj4ySruymcBCfrzKQmVQLCbbOGhyFMLqq0Q==
+
 "@types/ember__engine@*", "@types/ember__engine@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/ember__engine/-/ember__engine-4.0.0.tgz#e39c06d98c7a085912508e8257c48a70196c1a87"
@@ -5893,16 +5898,6 @@ ember-named-blocks-polyfill@^0.2.5:
   dependencies:
     ember-cli-babel "^7.19.0"
     ember-cli-version-checker "^5.1.1"
-
-ember-on-resize-modifier@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-on-resize-modifier/-/ember-on-resize-modifier-1.1.0.tgz#96b92cb190a552a8e240a2077037b0b71facc54e"
-  integrity sha512-Pz7muUcwzgAVGQ3ZNCdY/KMKtmvtJk5DWetuvx2MVHZCRpVzSRvkVa2tKXcp4tmz/COYUysneJxAR4tmwAyH9Q==
-  dependencies:
-    ember-cli-babel "^7.26.6"
-    ember-cli-htmlbars "^5.7.1"
-    ember-modifier "^3.2.7"
-    ember-resize-observer-service "^1.1.0"
 
 ember-page-title@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
## Description

`@ember/render-modifiers` provided a means to transition code to Octane, with the understanding that a custom modifier will eventually be in use.

This pull request makes the following changes:

- Reduced the number of modifiers invoked by the `<ContainerQuery>` component to 1
- Replaced `ember-on-resize-modifier` with `ember-resize-observer-service` (smaller external dependency)
- Made the `{{container-query}}` modifier responsible for managing the DOM (instead of the `<ContainerQuery>` component)
- Fixed autotracking bugs related to the arguments `@dataAttributePrefix` and `@features`
- Updated the components for demo app to call custom modifiers