### PR TITLE
Support strict mode (<template>) types (used in Glint)

### DIFF
--- a/addon/components/container-query.ts
+++ b/addon/components/container-query.ts
@@ -24,7 +24,24 @@ interface ContainerQueryComponentArgs {
   tagName?: string;
 }
 
-export default class ContainerQueryComponent extends Component<ContainerQueryComponentArgs> {
+interface Signature {
+  Element: HTMLElement;
+  Args: ContainerQueryComponentArgs;
+  Blocks: {
+    default: [
+      {
+        features: Features;
+        dimensions: {
+          aspectRatio: number;
+          height: number;
+          width: number;
+        };
+      }
+    ];
+  };
+}
+
+export default class ContainerQueryComponent extends Component<Signature> {
   @tracked queryResults = {} as QueryResults;
   @tracked aspectRatio?: number;
   @tracked height?: number;


### PR DESCRIPTION
This'll require `@glimmer/component` 1.1.2  -- but `@glimmer/component` support isn't declared, so this is a bit of a gray area in terms of support -- up to ya'll (especially since pre-strict mode, component types weren't used at all, except by maintainers)