### PR TITLE
Add easier imports from strict mode users

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,0 +1,4 @@
+export { default as ContainerQuery } from './components/container-query';
+export { default as aspectRatio } from './helpers/cq-aspect-ratio';
+export { default as height } from './helpers/cq-height';
+export { default as width } from './helpers/cq-width';

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -1,4 +1,5 @@
 export { default as ContainerQuery } from './components/container-query';
-export { default as aspectRatio } from './helpers/cq-aspect-ratio';
-export { default as height } from './helpers/cq-height';
-export { default as width } from './helpers/cq-width';
+export { default as aspectRatio } from './helpers/aspect-ratio';
+export { default as height } from './helpers/height';
+export { default as width } from './helpers/width';
+export { default as containerQuery } from './modifiers/container-query';


### PR DESCRIPTION
This will make imports a bit easier to manager for strict-mode / `<template>` users.
If folks don't want to include all of this in their bundle, they could enable tree shaking, or import from the loose-mode paths