### PR TITLE
Remove ember-cli-typescript. Enable enableTypeScriptTransform instead.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,6 +6,10 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function (defaults) {
   const app = new EmberAddon(defaults, {
     // Add options here
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
+
     fingerprint: {
       exclude: ['images/'],
     },

--- a/index.js
+++ b/index.js
@@ -2,4 +2,10 @@
 
 module.exports = {
   name: require('./package').name,
+
+  options: {
+    'ember-cli-babel': {
+      enableTypeScriptTransform: true,
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   "dependencies": {
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.1.1",
-    "ember-cli-typescript": "^5.2.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4850,7 +4850,7 @@ ember-cli-typescript@^4.2.1:
     stagehand "^1.0.0"
     walk-sync "^2.2.0"
 
-ember-cli-typescript@^5.0.0, ember-cli-typescript@^5.2.1:
+ember-cli-typescript@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz#553030f1ce3e8958b8e4fc34909acd1218cb35f2"
   integrity sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==


### PR DESCRIPTION
## Description

Installing `ember-cli-typescript` is not necessary in addons. According to [Dan Freeman](https://discord.com/channels/480462759797063690/491905849405472769/1006952580116643993):

> At this point the only thing `ember-cli-typescript` does for the addon during the app build is act as a signal to `ember-cli-babel` that it should include the TS transform and pick up `.ts` files
>
> (which you can also accomplish by setting `enableTypeScriptTransform: true` in your config 


## References

- https://github.com/babel/ember-cli-babel/pull/467