### PR TITLE
Refactor tests

### DIFF
--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -44,8 +44,6 @@ interface ContainerQueryModifierSignature {
 }
 
 export default class ContainerQueryModifier extends Modifier<ContainerQueryModifierSignature> {
-  /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-  /* @ts-ignore */
   @service private declare readonly resizeObserver;
 
   dimensions!: Dimensions;

--- a/tests/acceptance/album/accessibility-test.ts
+++ b/tests/acceptance/album/accessibility-test.ts
@@ -1,6 +1,5 @@
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'dummy/tests/helpers';
-import { timeout } from 'dummy/tests/helpers/resize-container';
+import { setupApplicationTest, timeout } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/album/accessibility-test.ts
+++ b/tests/acceptance/album/accessibility-test.ts
@@ -1,13 +1,11 @@
 import { visit } from '@ember/test-helpers';
-import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { setupApplicationTest } from 'dummy/tests/helpers';
 import { timeout } from 'dummy/tests/helpers/resize-container';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Acceptance | album', function (hooks) {
   setupApplicationTest(hooks);
-  resetViewport(hooks);
 
   hooks.beforeEach(async function () {
     await visit('/album');

--- a/tests/acceptance/album/visual-regression-test.ts
+++ b/tests/acceptance/album/visual-regression-test.ts
@@ -1,14 +1,12 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'dummy/tests/helpers';
 import takeSnapshot from 'dummy/tests/helpers/percy';
-import resetViewport from 'dummy/tests/helpers/reset-viewport';
 import { timeout } from 'dummy/tests/helpers/resize-container';
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Acceptance | album', function (hooks) {
   setupApplicationTest(hooks);
-  resetViewport(hooks);
 
   hooks.beforeEach(async function () {
     await visit('/album');

--- a/tests/acceptance/album/visual-regression-test.ts
+++ b/tests/acceptance/album/visual-regression-test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest, takeSnapshot } from 'dummy/tests/helpers';
-import { timeout } from 'dummy/tests/helpers/resize-container';
+import {
+  setupApplicationTest,
+  takeSnapshot,
+  timeout,
+} from 'dummy/tests/helpers';
 import { module, test } from 'qunit';
 
 module('Acceptance | album', function (hooks) {

--- a/tests/acceptance/album/visual-regression-test.ts
+++ b/tests/acceptance/album/visual-regression-test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'dummy/tests/helpers';
-import takeSnapshot from 'dummy/tests/helpers/percy';
+import { setupApplicationTest, takeSnapshot } from 'dummy/tests/helpers';
 import { timeout } from 'dummy/tests/helpers/resize-container';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/dashboard/accessibility-test.ts
+++ b/tests/acceptance/dashboard/accessibility-test.ts
@@ -1,6 +1,5 @@
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'dummy/tests/helpers';
-import { timeout } from 'dummy/tests/helpers/resize-container';
+import { setupApplicationTest, timeout } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/dashboard/accessibility-test.ts
+++ b/tests/acceptance/dashboard/accessibility-test.ts
@@ -1,13 +1,11 @@
 import { visit } from '@ember/test-helpers';
-import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { setupApplicationTest } from 'dummy/tests/helpers';
 import { timeout } from 'dummy/tests/helpers/resize-container';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Acceptance | dashboard', function (hooks) {
   setupApplicationTest(hooks);
-  resetViewport(hooks);
 
   hooks.beforeEach(async function () {
     await visit('/dashboard');

--- a/tests/acceptance/dashboard/visual-regression-test.ts
+++ b/tests/acceptance/dashboard/visual-regression-test.ts
@@ -1,14 +1,12 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'dummy/tests/helpers';
 import takeSnapshot from 'dummy/tests/helpers/percy';
-import resetViewport from 'dummy/tests/helpers/reset-viewport';
 import { timeout } from 'dummy/tests/helpers/resize-container';
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Acceptance | dashboard', function (hooks) {
   setupApplicationTest(hooks);
-  resetViewport(hooks);
 
   hooks.beforeEach(async function () {
     await visit('/dashboard');

--- a/tests/acceptance/dashboard/visual-regression-test.ts
+++ b/tests/acceptance/dashboard/visual-regression-test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest, takeSnapshot } from 'dummy/tests/helpers';
-import { timeout } from 'dummy/tests/helpers/resize-container';
+import {
+  setupApplicationTest,
+  takeSnapshot,
+  timeout,
+} from 'dummy/tests/helpers';
 import { module, test } from 'qunit';
 
 module('Acceptance | dashboard', function (hooks) {

--- a/tests/acceptance/dashboard/visual-regression-test.ts
+++ b/tests/acceptance/dashboard/visual-regression-test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'dummy/tests/helpers';
-import takeSnapshot from 'dummy/tests/helpers/percy';
+import { setupApplicationTest, takeSnapshot } from 'dummy/tests/helpers';
 import { timeout } from 'dummy/tests/helpers/resize-container';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/form/accessibility-test.ts
+++ b/tests/acceptance/form/accessibility-test.ts
@@ -1,6 +1,5 @@
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'dummy/tests/helpers';
-import { timeout } from 'dummy/tests/helpers/resize-container';
+import { setupApplicationTest, timeout } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/form/accessibility-test.ts
+++ b/tests/acceptance/form/accessibility-test.ts
@@ -1,13 +1,11 @@
 import { visit } from '@ember/test-helpers';
-import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { setupApplicationTest } from 'dummy/tests/helpers';
 import { timeout } from 'dummy/tests/helpers/resize-container';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Acceptance | form', function (hooks) {
   setupApplicationTest(hooks);
-  resetViewport(hooks);
 
   hooks.beforeEach(async function () {
     await visit('/form');

--- a/tests/acceptance/form/visual-regression-test.ts
+++ b/tests/acceptance/form/visual-regression-test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest, takeSnapshot } from 'dummy/tests/helpers';
-import { timeout } from 'dummy/tests/helpers/resize-container';
+import {
+  setupApplicationTest,
+  takeSnapshot,
+  timeout,
+} from 'dummy/tests/helpers';
 import { module, test } from 'qunit';
 
 module('Acceptance | form', function (hooks) {

--- a/tests/acceptance/form/visual-regression-test.ts
+++ b/tests/acceptance/form/visual-regression-test.ts
@@ -1,14 +1,12 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'dummy/tests/helpers';
 import takeSnapshot from 'dummy/tests/helpers/percy';
-import resetViewport from 'dummy/tests/helpers/reset-viewport';
 import { timeout } from 'dummy/tests/helpers/resize-container';
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Acceptance | form', function (hooks) {
   setupApplicationTest(hooks);
-  resetViewport(hooks);
 
   hooks.beforeEach(async function () {
     await visit('/form');

--- a/tests/acceptance/form/visual-regression-test.ts
+++ b/tests/acceptance/form/visual-regression-test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'dummy/tests/helpers';
-import takeSnapshot from 'dummy/tests/helpers/percy';
+import { setupApplicationTest, takeSnapshot } from 'dummy/tests/helpers';
 import { timeout } from 'dummy/tests/helpers/resize-container';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/index/accessibility-test.ts
+++ b/tests/acceptance/index/accessibility-test.ts
@@ -1,13 +1,11 @@
 import { visit } from '@ember/test-helpers';
-import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { setupApplicationTest } from 'dummy/tests/helpers';
 import { timeout } from 'dummy/tests/helpers/resize-container';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);
-  resetViewport(hooks);
 
   hooks.beforeEach(async function () {
     await visit('/');

--- a/tests/acceptance/index/accessibility-test.ts
+++ b/tests/acceptance/index/accessibility-test.ts
@@ -1,6 +1,5 @@
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'dummy/tests/helpers';
-import { timeout } from 'dummy/tests/helpers/resize-container';
+import { setupApplicationTest, timeout } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/not-found/accessibility-test.ts
+++ b/tests/acceptance/not-found/accessibility-test.ts
@@ -1,6 +1,5 @@
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest } from 'dummy/tests/helpers';
-import { timeout } from 'dummy/tests/helpers/resize-container';
+import { setupApplicationTest, timeout } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/not-found/accessibility-test.ts
+++ b/tests/acceptance/not-found/accessibility-test.ts
@@ -1,13 +1,11 @@
 import { visit } from '@ember/test-helpers';
-import resetViewport from 'dummy/tests/helpers/reset-viewport';
+import { setupApplicationTest } from 'dummy/tests/helpers';
 import { timeout } from 'dummy/tests/helpers/resize-container';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
-import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Acceptance | not-found', function (hooks) {
   setupApplicationTest(hooks);
-  resetViewport(hooks);
 
   hooks.beforeEach(async function () {
     await visit('/404');

--- a/tests/dummy/app/modifiers/dynamic-css-grid.ts
+++ b/tests/dummy/app/modifiers/dynamic-css-grid.ts
@@ -14,7 +14,7 @@ interface DynamicCssGridModifierSignature {
 export default modifier(
   function dynamicCssGrid(
     element: Element,
-    _: PositionalArgs<DynamicCssGridModifierSignature>,
+    _positional: PositionalArgs<DynamicCssGridModifierSignature>,
     named: NamedArgs<DynamicCssGridModifierSignature>
   ): void {
     const { numColumns, numRows } = named;

--- a/tests/dummy/app/modifiers/find-best-fitting-image.ts
+++ b/tests/dummy/app/modifiers/find-best-fitting-image.ts
@@ -18,7 +18,7 @@ interface FindBestFittingImageModifierSignature {
 export default modifier(
   function findBestFittingImage(
     element: Element,
-    _: PositionalArgs<FindBestFittingImageModifierSignature>,
+    _positional: PositionalArgs<FindBestFittingImageModifierSignature>,
     named: NamedArgs<FindBestFittingImageModifierSignature>
   ) {
     const { dimensions, images, onQuery } = named;

--- a/tests/helpers/container-query.ts
+++ b/tests/helpers/container-query.ts
@@ -4,16 +4,18 @@ type DataAttributes = {
   [dataAttributeName: string]: string | undefined;
 };
 
+type Dimensions = {
+  height: number;
+  width: number;
+};
+
 type Features = {
   [featureName: string]: boolean | undefined;
 };
 
 export interface CustomAssert extends Assert {
   areDataAttributesCorrect?: (dataAttributes: DataAttributes) => void;
-  areDimensionsCorrect?: (
-    expectedWidth: number,
-    expectedHeight: number
-  ) => void;
+  areDimensionsCorrect?: (dimensions: Dimensions) => void;
   areFeaturesCorrect?: (features: Features) => void;
 }
 
@@ -61,10 +63,9 @@ function setupCustomAssertions(assert: CustomAssert): void {
     }
   };
 
-  assert.areDimensionsCorrect = (
-    expectedWidth: number,
-    expectedHeight: number
-  ) => {
+  assert.areDimensionsCorrect = (dimensions) => {
+    const { height: expectedHeight, width: expectedWidth } = dimensions;
+
     // Check width and height
     assert
       .dom('[data-test-width-height]')

--- a/tests/helpers/container-query.ts
+++ b/tests/helpers/container-query.ts
@@ -17,7 +17,7 @@ export interface CustomAssert extends Assert {
   areFeaturesCorrect?: (features: Features) => void;
 }
 
-export default function setupContainerQueryTest(hooks: NestedHooks): void {
+export function setupContainerQueryTest(hooks: NestedHooks): void {
   hooks.beforeEach(setupCustomAssertions);
   hooks.afterEach(cleanupCustomAssertions);
 }

--- a/tests/helpers/container-query.ts
+++ b/tests/helpers/container-query.ts
@@ -25,39 +25,32 @@ export function setupContainerQueryTest(hooks: NestedHooks): void {
 }
 
 function setupCustomAssertions(assert: CustomAssert): void {
-  assert.areFeaturesCorrect = (features = {}) => {
-    for (const [featureName, meetsFeature] of Object.entries(features)) {
-      switch (meetsFeature) {
-        case true: {
-          assert
-            .dom(`[data-test-feature="${featureName}"]`)
-            .hasText(
-              'true',
-              `The container meets the feature "${featureName}".`
-            );
+  assert.areDataAttributesCorrect = (dataAttributes = {}) => {
+    const containerQuery = find('[data-test-container-query]');
 
-          break;
-        }
-
-        case false: {
-          assert
-            .dom(`[data-test-feature="${featureName}"]`)
-            .hasText(
-              'false',
-              `The container doesn't meet the feature "${featureName}".`
-            );
-
-          break;
-        }
-
+    for (const [dataAttributeName, expectedValue] of Object.entries(
+      dataAttributes
+    )) {
+      switch (expectedValue) {
         case undefined: {
           assert
-            .dom(`[data-test-feature="${featureName}"]`)
-            .hasNoText(
-              `The container doesn't meet the feature "${featureName}".`
+            .dom(containerQuery)
+            .doesNotHaveAttribute(
+              dataAttributeName,
+              `The container doesn't have the attribute "${dataAttributeName}".`
             );
 
           break;
+        }
+
+        default: {
+          assert
+            .dom(containerQuery)
+            .hasAttribute(
+              dataAttributeName,
+              expectedValue,
+              `The container has the attribute "${dataAttributeName}".`
+            );
         }
       }
     }
@@ -97,32 +90,39 @@ function setupCustomAssertions(assert: CustomAssert): void {
     assert.true(relativeError < tolerance, 'Aspect ratio is correct.');
   };
 
-  assert.areDataAttributesCorrect = (dataAttributes = {}) => {
-    const containerQuery = find('[data-test-container-query]');
-
-    for (const [dataAttributeName, expectedValue] of Object.entries(
-      dataAttributes
-    )) {
-      switch (expectedValue) {
-        case undefined: {
+  assert.areFeaturesCorrect = (features = {}) => {
+    for (const [featureName, meetsFeature] of Object.entries(features)) {
+      switch (meetsFeature) {
+        case true: {
           assert
-            .dom(containerQuery)
-            .doesNotHaveAttribute(
-              dataAttributeName,
-              `The container doesn't have the attribute "${dataAttributeName}".`
+            .dom(`[data-test-feature="${featureName}"]`)
+            .hasText(
+              'true',
+              `The container meets the feature "${featureName}".`
             );
 
           break;
         }
 
-        default: {
+        case false: {
           assert
-            .dom(containerQuery)
-            .hasAttribute(
-              dataAttributeName,
-              expectedValue,
-              `The container has the attribute "${dataAttributeName}".`
+            .dom(`[data-test-feature="${featureName}"]`)
+            .hasText(
+              'false',
+              `The container doesn't meet the feature "${featureName}".`
             );
+
+          break;
+        }
+
+        case undefined: {
+          assert
+            .dom(`[data-test-feature="${featureName}"]`)
+            .hasNoText(
+              `The container doesn't meet the feature "${featureName}".`
+            );
+
+          break;
         }
       }
     }
@@ -130,7 +130,7 @@ function setupCustomAssertions(assert: CustomAssert): void {
 }
 
 function cleanupCustomAssertions(assert: CustomAssert): void {
-  delete assert.areFeaturesCorrect;
-  delete assert.areDimensionsCorrect;
   delete assert.areDataAttributesCorrect;
+  delete assert.areDimensionsCorrect;
+  delete assert.areFeaturesCorrect;
 }

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -5,6 +5,8 @@ import {
 } from 'ember-qunit';
 import EmberResolver from 'ember-resolver';
 
+import resetViewport from './reset-viewport';
+
 interface SetupTestOptions {
   resolver?: EmberResolver | undefined;
 }
@@ -18,6 +20,7 @@ function setupApplicationTest(
   options?: SetupTestOptions
 ): void {
   upstreamSetupApplicationTest(hooks, options);
+  resetViewport(hooks);
 
   // Additional setup for application tests can be done here.
   //

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -54,3 +54,5 @@ function setupTest(hooks: NestedHooks, options?: SetupTestOptions): void {
 }
 
 export { setupApplicationTest, setupRenderingTest, setupTest };
+
+export * from './container-query';

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -56,3 +56,4 @@ function setupTest(hooks: NestedHooks, options?: SetupTestOptions): void {
 export { setupApplicationTest, setupRenderingTest, setupTest };
 
 export * from './container-query';
+export * from './percy';

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -58,3 +58,4 @@ export { setupApplicationTest, setupRenderingTest, setupTest };
 export * from './container-query';
 export * from './percy';
 export * from './reset-viewport';
+export * from './resize-container';

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -5,7 +5,7 @@ import {
 } from 'ember-qunit';
 import EmberResolver from 'ember-resolver';
 
-import resetViewport from './reset-viewport';
+import { resetViewport } from './reset-viewport';
 
 interface SetupTestOptions {
   resolver?: EmberResolver | undefined;
@@ -57,3 +57,4 @@ export { setupApplicationTest, setupRenderingTest, setupTest };
 
 export * from './container-query';
 export * from './percy';
+export * from './reset-viewport';

--- a/tests/helpers/percy.ts
+++ b/tests/helpers/percy.ts
@@ -66,7 +66,7 @@ type SnapshotOptions = {
     ...
   });
 */
-export default async function takeSnapshot(
+export async function takeSnapshot(
   qunitAssert: unknown,
   options: SnapshotOptions = {} as SnapshotOptions
 ): Promise<void> {

--- a/tests/helpers/reset-viewport.ts
+++ b/tests/helpers/reset-viewport.ts
@@ -4,7 +4,7 @@
 
   https://github.com/emberjs/ember-qunit/blob/master/vendor/ember-qunit/test-container-styles.css
 */
-export default function resetViewport(hooks: NestedHooks): void {
+export function resetViewport(hooks: NestedHooks): void {
   hooks.beforeEach(function () {
     const testingContainer = document.getElementById(
       'ember-testing-container'

--- a/tests/helpers/resize-container.ts
+++ b/tests/helpers/resize-container.ts
@@ -13,7 +13,7 @@ export function timeout(milliseconds = RERENDER_TIME): Promise<void> {
   });
 }
 
-export default async function resizeContainer(
+export async function resizeContainer(
   width: number,
   height: number
 ): Promise<void> {

--- a/tests/helpers/resize-container.ts
+++ b/tests/helpers/resize-container.ts
@@ -13,10 +13,13 @@ export function timeout(milliseconds = RERENDER_TIME): Promise<void> {
   });
 }
 
-export async function resizeContainer(
-  width: number,
-  height: number
-): Promise<void> {
+export async function resizeContainer({
+  height,
+  width,
+}: {
+  height: number;
+  width: number;
+}): Promise<void> {
   const parentElement = find('[data-test-parent-element]');
 
   assert(
@@ -27,8 +30,8 @@ export async function resizeContainer(
   // Since <ContainerQuery> has a style of `height: 100%; width: 100%;`,
   // we can set its parent element's width and height to cause container
   // queries to be evaluated.
-  (parentElement as HTMLElement).style.width = `${width}px`;
   (parentElement as HTMLElement).style.height = `${height}px`;
+  (parentElement as HTMLElement).style.width = `${width}px`;
 
   await timeout();
 }

--- a/tests/integration/components/container-query/dataAttributePrefix-test.ts
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.ts
@@ -3,10 +3,11 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
 import type { CustomAssert } from 'dummy/tests/helpers';
 import {
+  resizeContainer,
   setupContainerQueryTest,
   setupRenderingTest,
+  timeout,
 } from 'dummy/tests/helpers';
-import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 

--- a/tests/integration/components/container-query/dataAttributePrefix-test.ts
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.ts
@@ -74,7 +74,7 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component updates data attributes when it is resized', async function (assert: CustomAssert) {
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert.areDataAttributesCorrect!({
         'data-container-query-small': undefined,
@@ -87,7 +87,7 @@ module('Integration | Component | container-query', function (hooks) {
         'data-container-query-ratio-type-C': '',
       });
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert.areDataAttributesCorrect!({
         'data-container-query-small': undefined,
@@ -100,7 +100,7 @@ module('Integration | Component | container-query', function (hooks) {
         'data-container-query-ratio-type-C': undefined,
       });
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert.areDataAttributesCorrect!({
         'data-container-query-small': undefined,
@@ -173,7 +173,7 @@ module('Integration | Component | container-query', function (hooks) {
       });
 
       test('The component updates data attributes when it is resized', async function (assert: CustomAssert) {
-        await resizeContainer(500, 300);
+        await resizeContainer({ height: 300, width: 500 });
 
         assert.areDataAttributesCorrect!({
           'data-small': undefined,
@@ -186,7 +186,7 @@ module('Integration | Component | container-query', function (hooks) {
           'data-ratio-type-C': '',
         });
 
-        await resizeContainer(800, 400);
+        await resizeContainer({ height: 400, width: 800 });
 
         assert.areDataAttributesCorrect!({
           'data-small': undefined,
@@ -199,7 +199,7 @@ module('Integration | Component | container-query', function (hooks) {
           'data-ratio-type-C': undefined,
         });
 
-        await resizeContainer(1000, 600);
+        await resizeContainer({ height: 600, width: 1000 });
 
         assert.areDataAttributesCorrect!({
           'data-small': undefined,
@@ -273,7 +273,7 @@ module('Integration | Component | container-query', function (hooks) {
       });
 
       test('The component updates data attributes when it is resized', async function (assert: CustomAssert) {
-        await resizeContainer(500, 300);
+        await resizeContainer({ height: 300, width: 500 });
 
         assert.areDataAttributesCorrect!({
           'data-cq-small': undefined,
@@ -286,7 +286,7 @@ module('Integration | Component | container-query', function (hooks) {
           'data-cq-ratio-type-C': '',
         });
 
-        await resizeContainer(800, 400);
+        await resizeContainer({ height: 400, width: 800 });
 
         assert.areDataAttributesCorrect!({
           'data-cq-small': undefined,
@@ -299,7 +299,7 @@ module('Integration | Component | container-query', function (hooks) {
           'data-cq-ratio-type-C': undefined,
         });
 
-        await resizeContainer(1000, 600);
+        await resizeContainer({ height: 600, width: 1000 });
 
         assert.areDataAttributesCorrect!({
           'data-cq-small': undefined,
@@ -386,7 +386,7 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component updates the data attributes when it is resized', async function (assert: CustomAssert) {
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert.areDataAttributesCorrect!({
         'data-cq1-small': undefined,
@@ -410,7 +410,7 @@ module('Integration | Component | container-query', function (hooks) {
         'data-cq2-ratio-type-C': '',
       });
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert.areDataAttributesCorrect!({
         'data-cq1-small': undefined,
@@ -434,7 +434,7 @@ module('Integration | Component | container-query', function (hooks) {
         'data-cq2-ratio-type-C': undefined,
       });
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert.areDataAttributesCorrect!({
         'data-cq1-small': undefined,

--- a/tests/integration/components/container-query/dataAttributePrefix-test.ts
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.ts
@@ -1,9 +1,11 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
-import type { CustomAssert } from 'dummy/tests/helpers/container-query';
-import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
+import type { CustomAssert } from 'dummy/tests/helpers';
+import {
+  setupContainerQueryTest,
+  setupRenderingTest,
+} from 'dummy/tests/helpers';
 import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';

--- a/tests/integration/components/container-query/dataAttributePrefix-test.ts
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.ts
@@ -1,11 +1,11 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import type { CustomAssert } from 'dummy/tests/helpers/container-query';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
 import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 interface TestContext extends BaseTestContext {

--- a/tests/integration/components/container-query/debounce-test.ts
+++ b/tests/integration/components/container-query/debounce-test.ts
@@ -1,10 +1,10 @@
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import type { CustomAssert } from 'dummy/tests/helpers/container-query';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
 import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 interface TestContext extends BaseTestContext {

--- a/tests/integration/components/container-query/debounce-test.ts
+++ b/tests/integration/components/container-query/debounce-test.ts
@@ -2,10 +2,11 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
 import type { CustomAssert } from 'dummy/tests/helpers';
 import {
+  resizeContainer,
   setupContainerQueryTest,
   setupRenderingTest,
+  timeout,
 } from 'dummy/tests/helpers';
-import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 

--- a/tests/integration/components/container-query/debounce-test.ts
+++ b/tests/integration/components/container-query/debounce-test.ts
@@ -82,7 +82,7 @@ module('Integration | Component | container-query', function (hooks) {
 
       // After a resize, the container query results should remain the
       // same as before.
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert.areFeaturesCorrect!({
         small: true,
@@ -95,7 +95,7 @@ module('Integration | Component | container-query', function (hooks) {
         'ratio-type-C': false,
       });
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert.areFeaturesCorrect!({
         small: true,
@@ -108,7 +108,7 @@ module('Integration | Component | container-query', function (hooks) {
         'ratio-type-C': false,
       });
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert.areFeaturesCorrect!({
         small: true,

--- a/tests/integration/components/container-query/debounce-test.ts
+++ b/tests/integration/components/container-query/debounce-test.ts
@@ -1,8 +1,10 @@
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
-import type { CustomAssert } from 'dummy/tests/helpers/container-query';
-import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
+import type { CustomAssert } from 'dummy/tests/helpers';
+import {
+  setupContainerQueryTest,
+  setupRenderingTest,
+} from 'dummy/tests/helpers';
 import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';

--- a/tests/integration/components/container-query/features-test.ts
+++ b/tests/integration/components/container-query/features-test.ts
@@ -72,7 +72,7 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component updates features when it is resized', async function (assert: CustomAssert) {
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert.areFeaturesCorrect!({
         small: undefined,
@@ -85,7 +85,7 @@ module('Integration | Component | container-query', function (hooks) {
         'ratio-type-C': undefined,
       });
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert.areFeaturesCorrect!({
         small: undefined,
@@ -98,7 +98,7 @@ module('Integration | Component | container-query', function (hooks) {
         'ratio-type-C': undefined,
       });
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert.areFeaturesCorrect!({
         small: undefined,
@@ -113,15 +113,15 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component updates dimensions when it is resized', async function (assert: CustomAssert) {
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert.areDimensionsCorrect!(500, 300);
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert.areDimensionsCorrect!(800, 400);
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert.areDimensionsCorrect!(1000, 600);
     });
@@ -184,7 +184,7 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component updates features when it is resized', async function (assert: CustomAssert) {
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert.areFeaturesCorrect!({
         small: false,
@@ -197,7 +197,7 @@ module('Integration | Component | container-query', function (hooks) {
         'ratio-type-C': true,
       });
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert.areFeaturesCorrect!({
         small: false,
@@ -210,7 +210,7 @@ module('Integration | Component | container-query', function (hooks) {
         'ratio-type-C': false,
       });
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert.areFeaturesCorrect!({
         small: false,
@@ -225,15 +225,15 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component updates dimensions when it is resized', async function (assert: CustomAssert) {
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert.areDimensionsCorrect!(500, 300);
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert.areDimensionsCorrect!(800, 400);
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert.areDimensionsCorrect!(1000, 600);
     });
@@ -334,7 +334,7 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component updates features when it is resized', async function (assert: CustomAssert) {
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert.areFeaturesCorrect!({
         small: undefined,
@@ -350,7 +350,7 @@ module('Integration | Component | container-query', function (hooks) {
         'ratio-type-B': false,
       });
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert.areFeaturesCorrect!({
         small: undefined,
@@ -366,7 +366,7 @@ module('Integration | Component | container-query', function (hooks) {
         'ratio-type-B': false,
       });
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert.areFeaturesCorrect!({
         small: undefined,

--- a/tests/integration/components/container-query/features-test.ts
+++ b/tests/integration/components/container-query/features-test.ts
@@ -3,10 +3,11 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
 import type { CustomAssert } from 'dummy/tests/helpers';
 import {
+  resizeContainer,
   setupContainerQueryTest,
   setupRenderingTest,
+  timeout,
 } from 'dummy/tests/helpers';
-import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 

--- a/tests/integration/components/container-query/features-test.ts
+++ b/tests/integration/components/container-query/features-test.ts
@@ -1,9 +1,11 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
-import type { CustomAssert } from 'dummy/tests/helpers/container-query';
-import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
+import type { CustomAssert } from 'dummy/tests/helpers';
+import {
+  setupContainerQueryTest,
+  setupRenderingTest,
+} from 'dummy/tests/helpers';
 import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';

--- a/tests/integration/components/container-query/features-test.ts
+++ b/tests/integration/components/container-query/features-test.ts
@@ -68,7 +68,7 @@ module('Integration | Component | container-query', function (hooks) {
         'ratio-type-C': undefined,
       });
 
-      assert.areDimensionsCorrect!(250, 500);
+      assert.areDimensionsCorrect!({ height: 500, width: 250 });
     });
 
     test('The component updates features when it is resized', async function (assert: CustomAssert) {
@@ -115,15 +115,15 @@ module('Integration | Component | container-query', function (hooks) {
     test('The component updates dimensions when it is resized', async function (assert: CustomAssert) {
       await resizeContainer({ height: 300, width: 500 });
 
-      assert.areDimensionsCorrect!(500, 300);
+      assert.areDimensionsCorrect!({ height: 300, width: 500 });
 
       await resizeContainer({ height: 400, width: 800 });
 
-      assert.areDimensionsCorrect!(800, 400);
+      assert.areDimensionsCorrect!({ height: 400, width: 800 });
 
       await resizeContainer({ height: 600, width: 1000 });
 
-      assert.areDimensionsCorrect!(1000, 600);
+      assert.areDimensionsCorrect!({ height: 600, width: 1000 });
     });
   });
 
@@ -180,7 +180,7 @@ module('Integration | Component | container-query', function (hooks) {
         'ratio-type-C': false,
       });
 
-      assert.areDimensionsCorrect!(250, 500);
+      assert.areDimensionsCorrect!({ height: 500, width: 250 });
     });
 
     test('The component updates features when it is resized', async function (assert: CustomAssert) {
@@ -227,15 +227,15 @@ module('Integration | Component | container-query', function (hooks) {
     test('The component updates dimensions when it is resized', async function (assert: CustomAssert) {
       await resizeContainer({ height: 300, width: 500 });
 
-      assert.areDimensionsCorrect!(500, 300);
+      assert.areDimensionsCorrect!({ height: 300, width: 500 });
 
       await resizeContainer({ height: 400, width: 800 });
 
-      assert.areDimensionsCorrect!(800, 400);
+      assert.areDimensionsCorrect!({ height: 400, width: 800 });
 
       await resizeContainer({ height: 600, width: 1000 });
 
-      assert.areDimensionsCorrect!(1000, 600);
+      assert.areDimensionsCorrect!({ height: 600, width: 1000 });
     });
   });
 

--- a/tests/integration/components/container-query/features-test.ts
+++ b/tests/integration/components/container-query/features-test.ts
@@ -1,11 +1,11 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import type { CustomAssert } from 'dummy/tests/helpers/container-query';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
 import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 interface TestContext extends BaseTestContext {

--- a/tests/integration/components/container-query/splattributes-test.ts
+++ b/tests/integration/components/container-query/splattributes-test.ts
@@ -1,9 +1,9 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import type { CustomAssert } from 'dummy/tests/helpers/container-query';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
 import { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | container-query', function (hooks) {

--- a/tests/integration/components/container-query/splattributes-test.ts
+++ b/tests/integration/components/container-query/splattributes-test.ts
@@ -3,8 +3,8 @@ import type { CustomAssert } from 'dummy/tests/helpers';
 import {
   setupContainerQueryTest,
   setupRenderingTest,
+  timeout,
 } from 'dummy/tests/helpers';
-import { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 

--- a/tests/integration/components/container-query/splattributes-test.ts
+++ b/tests/integration/components/container-query/splattributes-test.ts
@@ -1,7 +1,9 @@
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
-import type { CustomAssert } from 'dummy/tests/helpers/container-query';
-import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
+import type { CustomAssert } from 'dummy/tests/helpers';
+import {
+  setupContainerQueryTest,
+  setupRenderingTest,
+} from 'dummy/tests/helpers';
 import { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';

--- a/tests/integration/components/container-query/tagName-test.ts
+++ b/tests/integration/components/container-query/tagName-test.ts
@@ -3,10 +3,11 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
 import type { CustomAssert } from 'dummy/tests/helpers';
 import {
+  resizeContainer,
   setupContainerQueryTest,
   setupRenderingTest,
+  timeout,
 } from 'dummy/tests/helpers';
-import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 

--- a/tests/integration/components/container-query/tagName-test.ts
+++ b/tests/integration/components/container-query/tagName-test.ts
@@ -1,9 +1,11 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
-import type { CustomAssert } from 'dummy/tests/helpers/container-query';
-import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
+import type { CustomAssert } from 'dummy/tests/helpers';
+import {
+  setupContainerQueryTest,
+  setupRenderingTest,
+} from 'dummy/tests/helpers';
 import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';

--- a/tests/integration/components/container-query/tagName-test.ts
+++ b/tests/integration/components/container-query/tagName-test.ts
@@ -67,19 +67,19 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component continues to have the <div> tag when it is resized', async function (assert: CustomAssert) {
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert
         .dom('[data-test-container-query]')
         .hasTagName('div', 'We see the correct tag name.');
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert
         .dom('[data-test-container-query]')
         .hasTagName('div', 'We see the correct tag name.');
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert
         .dom('[data-test-container-query]')
@@ -136,19 +136,19 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component continues to have the correct tag when it is resized', async function (assert: CustomAssert) {
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert
         .dom('[data-test-container-query]')
         .hasTagName('section', 'We see the correct tag name.');
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert
         .dom('[data-test-container-query]')
         .hasTagName('section', 'We see the correct tag name.');
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert
         .dom('[data-test-container-query]')
@@ -210,21 +210,21 @@ module('Integration | Component | container-query', function (hooks) {
     });
 
     test('The component continues to not update the tag when it is resized', async function (assert: CustomAssert) {
-      await resizeContainer(500, 300);
+      await resizeContainer({ height: 300, width: 500 });
 
       assert
         .dom('[data-test-container-query]')
         .hasTagName('section', 'We see the correct tag name.')
         .doesNotHaveTagName('article', 'The tag name should not change.');
 
-      await resizeContainer(800, 400);
+      await resizeContainer({ height: 400, width: 800 });
 
       assert
         .dom('[data-test-container-query]')
         .hasTagName('section', 'We see the correct tag name.')
         .doesNotHaveTagName('article', 'The tag name should not change.');
 
-      await resizeContainer(1000, 600);
+      await resizeContainer({ height: 600, width: 1000 });
 
       assert
         .dom('[data-test-container-query]')

--- a/tests/integration/components/container-query/tagName-test.ts
+++ b/tests/integration/components/container-query/tagName-test.ts
@@ -1,11 +1,11 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import type { CustomAssert } from 'dummy/tests/helpers/container-query';
 import setupContainerQueryTest from 'dummy/tests/helpers/container-query';
 import resizeContainer, { timeout } from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 interface TestContext extends BaseTestContext {

--- a/tests/integration/components/navigation-menu-test.ts
+++ b/tests/integration/components/navigation-menu-test.ts
@@ -1,6 +1,6 @@
 import { findAll, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | navigation-menu', function (hooks) {

--- a/tests/integration/components/tracks-test.ts
+++ b/tests/integration/components/tracks-test.ts
@@ -45,7 +45,7 @@ module('Integration | Component | tracks', function (hooks) {
       .doesNotExist("We don't see a table.");
 
     // Features: medium, short
-    await resizeContainer(560, 240);
+    await resizeContainer({ height: 240, width: 560 });
 
     assert
       .dom('[data-test-list="Tracks"]')
@@ -61,7 +61,7 @@ module('Integration | Component | tracks', function (hooks) {
       .doesNotExist("We don't see a table.");
 
     // Features: large, short
-    await resizeContainer(880, 240);
+    await resizeContainer({ height: 240, width: 880 });
 
     assert
       .dom('[data-test-list="Tracks"]')
@@ -77,7 +77,7 @@ module('Integration | Component | tracks', function (hooks) {
       .doesNotExist("We don't see a table.");
 
     // Features: small, tall
-    await resizeContainer(240, 640);
+    await resizeContainer({ height: 640, width: 240 });
 
     assert
       .dom('[data-test-list="Tracks"]')
@@ -93,7 +93,7 @@ module('Integration | Component | tracks', function (hooks) {
       .doesNotExist("We don't see a table.");
 
     // Features: medium, tall
-    await resizeContainer(560, 640);
+    await resizeContainer({ height: 640, width: 560 });
 
     assert
       .dom('[data-test-list="Tracks"]')
@@ -109,7 +109,7 @@ module('Integration | Component | tracks', function (hooks) {
       .doesNotExist("We don't see a table.");
 
     // Features: large, tall
-    await resizeContainer(880, 640);
+    await resizeContainer({ height: 640, width: 880 });
 
     assert
       .dom('[data-test-list="Tracks"]')

--- a/tests/integration/components/tracks-test.ts
+++ b/tests/integration/components/tracks-test.ts
@@ -2,9 +2,9 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
 import type { Album } from 'dummy/data/album';
 import albumData from 'dummy/data/album';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import resizeContainer from 'dummy/tests/helpers/resize-container';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 interface TestContext extends BaseTestContext {

--- a/tests/integration/components/tracks-test.ts
+++ b/tests/integration/components/tracks-test.ts
@@ -2,8 +2,7 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
 import type { Album } from 'dummy/data/album';
 import albumData from 'dummy/data/album';
-import { setupRenderingTest } from 'dummy/tests/helpers';
-import resizeContainer from 'dummy/tests/helpers/resize-container';
+import { resizeContainer, setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 

--- a/tests/integration/components/tracks/list-test.ts
+++ b/tests/integration/components/tracks/list-test.ts
@@ -2,8 +2,8 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { findAll, render } from '@ember/test-helpers';
 import type { Track } from 'dummy/data/album';
 import albumData from 'dummy/data/album';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 type TrackProperties = {

--- a/tests/integration/components/tracks/table-test.ts
+++ b/tests/integration/components/tracks/table-test.ts
@@ -2,8 +2,8 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { findAll, render } from '@ember/test-helpers';
 import type { Track } from 'dummy/data/album';
 import albumData from 'dummy/data/album';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 type TrackProperties = {

--- a/tests/integration/components/ui/form-test.ts
+++ b/tests/integration/components/ui/form-test.ts
@@ -1,6 +1,6 @@
 import { find, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | ui/form', function (hooks) {

--- a/tests/integration/components/ui/form/checkbox-test.ts
+++ b/tests/integration/components/ui/form/checkbox-test.ts
@@ -1,8 +1,8 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { click, render, triggerKeyEvent } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 type Changeset = {

--- a/tests/integration/components/ui/form/field-test.ts
+++ b/tests/integration/components/ui/form/field-test.ts
@@ -1,7 +1,7 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | ui/form/field', function (hooks) {

--- a/tests/integration/components/ui/form/information-test.ts
+++ b/tests/integration/components/ui/form/information-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | ui/form/information', function (hooks) {

--- a/tests/integration/components/ui/form/input-test.ts
+++ b/tests/integration/components/ui/form/input-test.ts
@@ -1,8 +1,8 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { fillIn, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 type Changeset = {

--- a/tests/integration/components/ui/form/textarea-test.ts
+++ b/tests/integration/components/ui/form/textarea-test.ts
@@ -1,8 +1,8 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { fillIn, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 type Changeset = {

--- a/tests/integration/components/ui/page-test.ts
+++ b/tests/integration/components/ui/page-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | ui/page', function (hooks) {

--- a/tests/integration/components/widgets/widget-1-test.ts
+++ b/tests/integration/components/widgets/widget-1-test.ts
@@ -1,6 +1,6 @@
 import { findAll, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | widgets/widget-1', function (hooks) {

--- a/tests/integration/components/widgets/widget-2-test.ts
+++ b/tests/integration/components/widgets/widget-2-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | widgets/widget-2', function (hooks) {

--- a/tests/integration/components/widgets/widget-3-test.ts
+++ b/tests/integration/components/widgets/widget-3-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | widgets/widget-3', function (hooks) {

--- a/tests/integration/components/widgets/widget-4-test.ts
+++ b/tests/integration/components/widgets/widget-4-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | widgets/widget-4', function (hooks) {

--- a/tests/integration/components/widgets/widget-5-test.ts
+++ b/tests/integration/components/widgets/widget-5-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Component | widgets/widget-5', function (hooks) {

--- a/tests/integration/helpers/cq-aspect-ratio-test.ts
+++ b/tests/integration/helpers/cq-aspect-ratio-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Helper | cq-aspect-ratio', function (hooks) {

--- a/tests/integration/helpers/cq-height-test.ts
+++ b/tests/integration/helpers/cq-height-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Helper | cq-height', function (hooks) {

--- a/tests/integration/helpers/cq-width-test.ts
+++ b/tests/integration/helpers/cq-width-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Helper | cq-width', function (hooks) {

--- a/tests/integration/modifiers/container-query-test.ts
+++ b/tests/integration/modifiers/container-query-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Modifier | container-query', function (hooks) {

--- a/tests/integration/modifiers/draw-chart-test.ts
+++ b/tests/integration/modifiers/draw-chart-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Modifier | draw-chart', function (hooks) {

--- a/tests/integration/modifiers/dynamic-css-grid-test.ts
+++ b/tests/integration/modifiers/dynamic-css-grid-test.ts
@@ -1,6 +1,6 @@
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 module('Integration | Modifier | dynamic-css-grid', function (hooks) {

--- a/tests/integration/modifiers/find-best-fitting-image-test.ts
+++ b/tests/integration/modifiers/find-best-fitting-image-test.ts
@@ -1,7 +1,7 @@
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 interface TestContext extends BaseTestContext {

--- a/tests/integration/modifiers/find-best-fitting-image-test.ts
+++ b/tests/integration/modifiers/find-best-fitting-image-test.ts
@@ -12,8 +12,9 @@ module('Integration | Modifier | find-best-fitting-image', function (hooks) {
   setupRenderingTest(hooks);
 
   test('We can find the best-fitting image', async function (this: TestContext, assert) {
-    /* eslint-disable-next-line @typescript-eslint/no-empty-function */
-    this.noOp = () => {};
+    this.noOp = () => {
+      // Do nothing
+    };
 
     await render(hbs`
       <div


### PR DESCRIPTION
## Description

Since Ember `v4.3`, test setups and custom assertions can be re-exported from `tests/helpers/index.{js,ts}` so that they are easier to import. The work that's needed to achieve this happens in the first 6 commits.

In commits 7-8, I removed the order dependency (used named arguments instead of positional) in `resizeContainer` and `assert.areFeaturesCorrect`. This way, the meaning of the passed values will be clear.


## References

- https://blog.emberjs.com/ember-released-4-3