### PR TITLE
Add Glint signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,32 @@ Installation
 ember install ember-container-query
 ```
 
+<details>
+<summary>Use Glint? ✨</summary>
+
+- If you are using [strict mode](http://emberjs.github.io/rfcs/0496-handlebars-strict-mode.html) (via [first-class component templates](http://emberjs.github.io/rfcs/0779-first-class-component-templates.html)), then you are good to go!
+
+- Otherwise, update your template registry to extend this addon's. Check the [Glint documentation](https://typed-ember.gitbook.io/glint/using-glint/ember/using-addons#using-glint-enabled-addons) for more information.
+
+    ```ts
+    /* types/global.d.ts */
+
+    import '@glint/environment-ember-loose';
+
+    import type EmberContainerQueryRegistry from 'ember-container-query/template-registry';
+
+    declare module '@glint/environment-ember-loose/registry' {
+      export default interface Registry extends EmberContainerQueryRegistry, /* other addon registries */ {
+        // local entries
+      }
+    }
+    ```
+
+
+⚠️ Glint is in active development and may introduce breaking changes. This addon will try to provide a stable API. Should it need to make a breaking change due to Glint, semantic versioning may not be rigorously followed (e.g. there is no new major version).
+
+</details>
+
 
 Applications
 ------------------------------------------------------------------------------

--- a/addon/components/container-query.hbs
+++ b/addon/components/container-query.hbs
@@ -1,3 +1,4 @@
+{{! @glint-ignore: ember-element-helper needs to provide Glint signature }}
 {{#let (element this.tagName) as |Tag|}}
   <Tag
     class="container-query"

--- a/addon/components/container-query.ts
+++ b/addon/components/container-query.ts
@@ -7,14 +7,25 @@ import type {
   QueryResults,
 } from 'ember-container-query/modifiers/container-query';
 
-interface ContainerQueryComponentArgs {
-  dataAttributePrefix?: string;
-  debounce?: number;
-  features?: Features;
-  tagName?: string;
+interface ContainerQueryComponentSignature {
+  Args: {
+    dataAttributePrefix?: string;
+    debounce?: number;
+    features?: Features;
+    tagName?: string;
+  };
+  Blocks: {
+    default: [
+      {
+        dimensions?: Dimensions;
+        features?: QueryResults;
+      }
+    ];
+  };
+  Element: HTMLElement;
 }
 
-export default class ContainerQueryComponent extends Component<ContainerQueryComponentArgs> {
+export default class ContainerQueryComponent extends Component<ContainerQueryComponentSignature> {
   @tracked dimensions?: Dimensions;
   @tracked queryResults?: QueryResults;
 

--- a/addon/components/container-query.ts
+++ b/addon/components/container-query.ts
@@ -4,30 +4,33 @@ import { tracked } from '@glimmer/tracking';
 import type {
   Dimensions,
   Features,
+  IndexSignatureParameter,
   QueryResults,
 } from 'ember-container-query/modifiers/container-query';
 
-interface ContainerQueryComponentSignature {
+interface ContainerQueryComponentSignature<T extends IndexSignatureParameter> {
   Args: {
     dataAttributePrefix?: string;
     debounce?: number;
-    features?: Features;
+    features?: Features<T>;
     tagName?: string;
   };
   Blocks: {
     default: [
       {
         dimensions?: Dimensions;
-        features?: QueryResults;
+        features?: QueryResults<T>;
       }
     ];
   };
   Element: HTMLElement;
 }
 
-export default class ContainerQueryComponent extends Component<ContainerQueryComponentSignature> {
+export default class ContainerQueryComponent<
+  T extends IndexSignatureParameter
+> extends Component<ContainerQueryComponentSignature<T>> {
   @tracked dimensions?: Dimensions;
-  @tracked queryResults?: QueryResults;
+  @tracked queryResults?: QueryResults<T>;
 
   // The dynamic tag is restricted to be immutable
   tagName = this.args.tagName ?? 'div';
@@ -37,7 +40,7 @@ export default class ContainerQueryComponent extends Component<ContainerQueryCom
     queryResults,
   }: {
     dimensions: Dimensions;
-    queryResults: QueryResults;
+    queryResults: QueryResults<T>;
   }): void {
     this.dimensions = dimensions;
     this.queryResults = queryResults;

--- a/addon/helpers/cq-aspect-ratio.ts
+++ b/addon/helpers/cq-aspect-ratio.ts
@@ -1,15 +1,25 @@
 import { helper } from '@ember/component/helper';
 import type { Metadata } from 'ember-container-query/modifiers/container-query';
 
-function cqAspectRatio(
-  positional: unknown[],
-  named: Record<string, unknown>
-): Metadata {
-  const dimension = 'aspectRatio';
-  const max = (named['max'] as number | undefined) ?? Infinity;
-  const min = (named['min'] as number | undefined) ?? 0;
-
-  return { dimension, max, min };
+interface CqAspectRatioHelperSignature {
+  Args: {
+    Named: {
+      max?: number;
+      min?: number;
+    };
+    Positional: [];
+  };
+  Return: Metadata;
 }
 
-export default helper(cqAspectRatio);
+const CqAspectRatioHelper = helper<CqAspectRatioHelperSignature>(
+  (_positional, named) => {
+    const dimension = 'aspectRatio';
+    const max = named.max ?? Infinity;
+    const min = named.min ?? 0;
+
+    return { dimension, max, min };
+  }
+);
+
+export default CqAspectRatioHelper;

--- a/addon/helpers/cq-height.ts
+++ b/addon/helpers/cq-height.ts
@@ -1,15 +1,23 @@
 import { helper } from '@ember/component/helper';
 import type { Metadata } from 'ember-container-query/modifiers/container-query';
 
-function cqHeight(
-  positional: unknown[],
-  named: Record<string, unknown>
-): Metadata {
-  const dimension = 'height';
-  const max = (named['max'] as number | undefined) ?? Infinity;
-  const min = (named['min'] as number | undefined) ?? 0;
-
-  return { dimension, max, min };
+interface CqHeightHelperSignature {
+  Args: {
+    Named: {
+      max?: number;
+      min?: number;
+    };
+    Positional: [];
+  };
+  Return: Metadata;
 }
 
-export default helper(cqHeight);
+const CqHeightHelper = helper<CqHeightHelperSignature>((_positional, named) => {
+  const dimension = 'height';
+  const max = named.max ?? Infinity;
+  const min = named.min ?? 0;
+
+  return { dimension, max, min };
+});
+
+export default CqHeightHelper;

--- a/addon/helpers/cq-width.ts
+++ b/addon/helpers/cq-width.ts
@@ -1,15 +1,23 @@
 import { helper } from '@ember/component/helper';
 import type { Metadata } from 'ember-container-query/modifiers/container-query';
 
-function cqWidth(
-  positional: unknown[],
-  named: Record<string, unknown>
-): Metadata {
-  const dimension = 'width';
-  const max = (named['max'] as number | undefined) ?? Infinity;
-  const min = (named['min'] as number | undefined) ?? 0;
-
-  return { dimension, max, min };
+interface CqWidthHelperSignature {
+  Args: {
+    Named: {
+      max?: number;
+      min?: number;
+    };
+    Positional: [];
+  };
+  Return: Metadata;
 }
 
-export default helper(cqWidth);
+const CqWidthHelper = helper<CqWidthHelperSignature>((_positional, named) => {
+  const dimension = 'width';
+  const max = named.max ?? Infinity;
+  const min = named.min ?? 0;
+
+  return { dimension, max, min };
+});
+
+export default CqWidthHelper;

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -4,23 +4,23 @@ import { debounce as _debounce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import Modifier, { ArgsFor, NamedArgs, PositionalArgs } from 'ember-modifier';
 
-export type Metadata = {
-  dimension: 'aspectRatio' | 'height' | 'width';
-  max: number;
-  min: number;
-};
-
-export type Features = {
-  [featureName: string]: Metadata;
-};
-
-export type Dimensions = {
+type Dimensions = {
   aspectRatio: number;
   height: number;
   width: number;
 };
 
-export type QueryResults = {
+type Metadata = {
+  dimension: 'aspectRatio' | 'height' | 'width';
+  max: number;
+  min: number;
+};
+
+type Features = {
+  [featureName: string]: Metadata;
+};
+
+type QueryResults = {
   [featureName: string]: boolean;
 };
 
@@ -166,3 +166,5 @@ export default class ContainerQueryModifier extends Modifier<ContainerQueryModif
     }
   }
 }
+
+export { Dimensions, Features, Metadata, QueryResults };

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -16,13 +16,9 @@ type Metadata = {
   min: number;
 };
 
-type Features = {
-  [featureName: string]: Metadata;
-};
+type Features = Record<string, Metadata>;
 
-type QueryResults = {
-  [featureName: string]: boolean;
-};
+type QueryResults = Record<string, boolean>;
 
 interface ContainerQueryModifierSignature {
   Args: {

--- a/addon/template-registry.ts
+++ b/addon/template-registry.ts
@@ -2,9 +2,11 @@ import type ContainerQueryComponent from 'ember-container-query/components/conta
 import type CqAspectRatioHelper from 'ember-container-query/helpers/cq-aspect-ratio';
 import type CqHeightHelper from 'ember-container-query/helpers/cq-height';
 import type CqWidthHelper from 'ember-container-query/helpers/cq-width';
+import type ContainerQueryModifier from 'ember-container-query/modifiers/container-query';
 
 export default interface EmberContainerQueryRegistry {
   ContainerQuery: typeof ContainerQueryComponent;
+  'container-query': typeof ContainerQueryModifier;
   'cq-aspect-ratio': typeof CqAspectRatioHelper;
   'cq-height': typeof CqHeightHelper;
   'cq-width': typeof CqWidthHelper;

--- a/addon/template-registry.ts
+++ b/addon/template-registry.ts
@@ -1,7 +1,9 @@
 import type ContainerQueryComponent from 'ember-container-query/components/container-query';
 import type CqAspectRatioHelper from 'ember-container-query/helpers/cq-aspect-ratio';
+import type CqHeightHelper from 'ember-container-query/helpers/cq-height';
 
 export default interface EmberContainerQueryRegistry {
   ContainerQuery: typeof ContainerQueryComponent;
   'cq-aspect-ratio': typeof CqAspectRatioHelper;
+  'cq-height': typeof CqHeightHelper;
 }

--- a/addon/template-registry.ts
+++ b/addon/template-registry.ts
@@ -1,0 +1,5 @@
+import type ContainerQueryComponent from 'ember-container-query/components/container-query';
+
+export default interface EmberContainerQueryRegistry {
+  ContainerQuery: typeof ContainerQueryComponent;
+}

--- a/addon/template-registry.ts
+++ b/addon/template-registry.ts
@@ -1,5 +1,7 @@
 import type ContainerQueryComponent from 'ember-container-query/components/container-query';
+import type CqAspectRatioHelper from 'ember-container-query/helpers/cq-aspect-ratio';
 
 export default interface EmberContainerQueryRegistry {
   ContainerQuery: typeof ContainerQueryComponent;
+  'cq-aspect-ratio': typeof CqAspectRatioHelper;
 }

--- a/addon/template-registry.ts
+++ b/addon/template-registry.ts
@@ -1,9 +1,11 @@
 import type ContainerQueryComponent from 'ember-container-query/components/container-query';
 import type CqAspectRatioHelper from 'ember-container-query/helpers/cq-aspect-ratio';
 import type CqHeightHelper from 'ember-container-query/helpers/cq-height';
+import type CqWidthHelper from 'ember-container-query/helpers/cq-width';
 
 export default interface EmberContainerQueryRegistry {
   ContainerQuery: typeof ContainerQueryComponent;
   'cq-aspect-ratio': typeof CqAspectRatioHelper;
   'cq-height': typeof CqHeightHelper;
+  'cq-width': typeof CqWidthHelper;
 }

--- a/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -3,10 +3,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import type { Image } from 'dummy/data/concert';
 import { findBestFittingImage } from 'dummy/utils/components/widgets/widget-3';
-import type {
-  Dimensions,
-  QueryResults,
-} from 'ember-container-query/modifiers/container-query';
+import type { Dimensions } from 'ember-container-query/modifiers/container-query';
 
 interface WidgetsWidget3TourScheduleResponsiveImageComponentArgs {
   images: Array<Image>;
@@ -15,12 +12,7 @@ interface WidgetsWidget3TourScheduleResponsiveImageComponentArgs {
 export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentArgs> {
   @tracked imageSource?: string;
 
-  @action setImageSource({
-    dimensions,
-  }: {
-    dimensions: Dimensions;
-    queryResults: QueryResults;
-  }): void {
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
     const { images } = this.args;
 
     this.imageSource = findBestFittingImage(images, dimensions);


### PR DESCRIPTION
## Description

> Glint is a set of tools to aid in developing code that uses the Glimmer VM for rendering, such as [Ember.js](https://www.emberjs.com/) v3.24+ and [GlimmerX](https://github.com/glimmerjs/glimmer-experimental) projects. [...] Glint consists of a CLI and a language server to provide feedback and enforce correctness both locally during editing and project-wide in CI. - https://typed-ember.gitbook.io/glint/

Inspired by #129, I wanted to learn more about Glint. What better way than updating this project to support it?

Introducing Glint helped me realize, the current types aren't specific enough and will result in a poor developer experience when the TypeScript configuration flag `noPropertyAccessFromIndexSignature` is set to `true` (e.g. because it was [enforced by `@tsconfig/ember`](https://github.com/tsconfig/bases/blob/main/bases/ember.json#L44)).

Namely, `QueryResults` was assumed to be an index signature with `string` keys, even though we actually know more: the keys must match a feature name that an end-developer provided. Unless we can encode this knowledge in `QueryResults`, the end-developer will be forced to migrate the template syntax from, e.g. `CQ.features.small` (using the dot notation), to `{{get CQ.features "small"}}` (using the `{{get}}` helper). This may be considered a breaking change.

I updated the demo app in #141 to show that (1) an app can consume `ember-container-query`'s template registry and (2) the updated types ("narrowed") are correct. Now that `QueryResults` has been narrowed, end-developers can continue to use the dot notation in templates.


## Screenshots

Before, with index signature:

<img width="900" alt="" src="https://user-images.githubusercontent.com/16869656/207919384-9bef19a5-06d5-428e-a5a6-64f60785612b.png">

<img width="900" alt="" src="https://user-images.githubusercontent.com/16869656/207919389-02825c68-ce2e-4714-87ea-7a37cc42f413.png">


After, with narrowed type:

<img width="900" alt="" src="https://user-images.githubusercontent.com/16869656/207919392-9f385ca1-19c9-426f-ab11-3f7d72b76756.png">

<img width="900" alt="" src="https://user-images.githubusercontent.com/16869656/207919397-883d2e86-8bf4-48b6-bf2a-22e8e79c4958.png">

<img width="900" alt="" src="https://user-images.githubusercontent.com/16869656/207919402-86109094-9bd4-4a04-a419-cd2904b01850.png">


## References

- https://typed-ember.gitbook.io/glint/using-glint/ember/component-signatures
- https://typed-ember.gitbook.io/glint/using-glint/ember/helper-and-modifier-signatures
- https://typed-ember.gitbook.io/glint/using-glint/ember/template-registry