### PR TITLE
Use relative paths whenever possible

### DIFF
--- a/addon/components/container-query.ts
+++ b/addon/components/container-query.ts
@@ -1,12 +1,13 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+
 import type {
   Dimensions,
   Features,
   IndexSignatureParameter,
   QueryResults,
-} from 'ember-container-query/modifiers/container-query';
+} from '../modifiers/container-query';
 
 interface ContainerQueryComponentSignature<T extends IndexSignatureParameter> {
   Args: {

--- a/addon/helpers/aspect-ratio.ts
+++ b/addon/helpers/aspect-ratio.ts
@@ -1,5 +1,6 @@
 import { helper } from '@ember/component/helper';
-import type { Metadata } from 'ember-container-query/modifiers/container-query';
+
+import type { Metadata } from '../modifiers/container-query';
 
 interface AspectRatioHelperSignature {
   Args: {

--- a/addon/helpers/height.ts
+++ b/addon/helpers/height.ts
@@ -1,5 +1,6 @@
 import { helper } from '@ember/component/helper';
-import type { Metadata } from 'ember-container-query/modifiers/container-query';
+
+import type { Metadata } from '../modifiers/container-query';
 
 interface HeightHelperSignature {
   Args: {

--- a/addon/helpers/width.ts
+++ b/addon/helpers/width.ts
@@ -1,5 +1,6 @@
 import { helper } from '@ember/component/helper';
-import type { Metadata } from 'ember-container-query/modifiers/container-query';
+
+import type { Metadata } from '../modifiers/container-query';
 
 interface WidthHelperSignature {
   Args: {

--- a/addon/template-registry.ts
+++ b/addon/template-registry.ts
@@ -1,8 +1,8 @@
-import type ContainerQueryComponent from 'ember-container-query/components/container-query';
-import type AspectRatioHelper from 'ember-container-query/helpers/aspect-ratio';
-import type HeightHelper from 'ember-container-query/helpers/height';
-import type WidthHelper from 'ember-container-query/helpers/width';
-import type ContainerQueryModifier from 'ember-container-query/modifiers/container-query';
+import type ContainerQueryComponent from './components/container-query';
+import type AspectRatioHelper from './helpers/aspect-ratio';
+import type HeightHelper from './helpers/height';
+import type WidthHelper from './helpers/width';
+import type ContainerQueryModifier from './modifiers/container-query';
 
 export default interface EmberContainerQueryRegistry {
   ContainerQuery: typeof ContainerQueryComponent;

--- a/tests/acceptance/album/accessibility-test.ts
+++ b/tests/acceptance/album/accessibility-test.ts
@@ -1,7 +1,8 @@
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest, timeout } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
+
+import { setupApplicationTest, timeout } from '../../helpers';
 
 module('Acceptance | album', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/album/visual-regression-test.ts
+++ b/tests/acceptance/album/visual-regression-test.ts
@@ -1,11 +1,8 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import {
-  setupApplicationTest,
-  takeSnapshot,
-  timeout,
-} from 'dummy/tests/helpers';
 import { module, test } from 'qunit';
+
+import { setupApplicationTest, takeSnapshot, timeout } from '../../helpers';
 
 module('Acceptance | album', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/dashboard/accessibility-test.ts
+++ b/tests/acceptance/dashboard/accessibility-test.ts
@@ -1,7 +1,8 @@
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest, timeout } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
+
+import { setupApplicationTest, timeout } from '../../helpers';
 
 module('Acceptance | dashboard', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/dashboard/visual-regression-test.ts
+++ b/tests/acceptance/dashboard/visual-regression-test.ts
@@ -1,11 +1,8 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import {
-  setupApplicationTest,
-  takeSnapshot,
-  timeout,
-} from 'dummy/tests/helpers';
 import { module, test } from 'qunit';
+
+import { setupApplicationTest, takeSnapshot, timeout } from '../../helpers';
 
 module('Acceptance | dashboard', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/form/accessibility-test.ts
+++ b/tests/acceptance/form/accessibility-test.ts
@@ -1,7 +1,8 @@
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest, timeout } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
+
+import { setupApplicationTest, timeout } from '../../helpers';
 
 module('Acceptance | form', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/form/visual-regression-test.ts
+++ b/tests/acceptance/form/visual-regression-test.ts
@@ -1,11 +1,8 @@
 /* eslint-disable qunit/require-expect */
 import { visit } from '@ember/test-helpers';
-import {
-  setupApplicationTest,
-  takeSnapshot,
-  timeout,
-} from 'dummy/tests/helpers';
 import { module, test } from 'qunit';
+
+import { setupApplicationTest, takeSnapshot, timeout } from '../../helpers';
 
 module('Acceptance | form', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/index/accessibility-test.ts
+++ b/tests/acceptance/index/accessibility-test.ts
@@ -1,7 +1,8 @@
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest, timeout } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
+
+import { setupApplicationTest, timeout } from '../../helpers';
 
 module('Acceptance | index', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/not-found/accessibility-test.ts
+++ b/tests/acceptance/not-found/accessibility-test.ts
@@ -1,7 +1,8 @@
 import { visit } from '@ember/test-helpers';
-import { setupApplicationTest, timeout } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { module, test } from 'qunit';
+
+import { setupApplicationTest, timeout } from '../../helpers';
 
 module('Acceptance | not-found', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/dummy/app/app.ts
+++ b/tests/dummy/app/app.ts
@@ -1,7 +1,8 @@
 import Application from '@ember/application';
-import config from 'dummy/config/environment';
 import loadInitializers from 'ember-load-initializers';
 import Resolver from 'ember-resolver';
+
+import config from './config/environment';
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;

--- a/tests/dummy/app/components/tracks.ts
+++ b/tests/dummy/app/components/tracks.ts
@@ -1,5 +1,6 @@
 import templateOnlyComponent from '@ember/component/template-only';
-import type { Track } from 'dummy/data/album';
+
+import type { Track } from '../data/album';
 
 interface TracksComponentSignature {
   Args: {

--- a/tests/dummy/app/components/tracks/list.ts
+++ b/tests/dummy/app/components/tracks/list.ts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
-import type { Track } from 'dummy/data/album';
+
+import type { Track } from '../../data/album';
 
 interface TracksListComponentSignature {
   Args: {

--- a/tests/dummy/app/components/tracks/table.ts
+++ b/tests/dummy/app/components/tracks/table.ts
@@ -1,5 +1,6 @@
 import templateOnlyComponent from '@ember/component/template-only';
-import type { Track } from 'dummy/data/album';
+
+import type { Track } from '../../data/album';
 
 interface TracksTableComponentSignature {
   Args: {

--- a/tests/dummy/app/components/ui/form.ts
+++ b/tests/dummy/app/components/ui/form.ts
@@ -3,9 +3,10 @@ import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { WithBoundArgs } from '@glint/template';
-import type UiFormCheckboxComponent from 'dummy/components/ui/form/checkbox';
-import type UiFormInputComponent from 'dummy/components/ui/form/input';
-import type UiFormTextareaComponent from 'dummy/components/ui/form/textarea';
+
+import type UiFormCheckboxComponent from './form/checkbox';
+import type UiFormInputComponent from './form/input';
+import type UiFormTextareaComponent from './form/textarea';
 
 interface UiFormComponentSignature {
   Args: {

--- a/tests/dummy/app/components/widgets/widget-2.ts
+++ b/tests/dummy/app/components/widgets/widget-2.ts
@@ -1,11 +1,12 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import musicRevenue from 'dummy/data/music-revenue';
-import type { Data, Summary } from 'dummy/utils/components/widgets/widget-2';
+
+import musicRevenue from '../../data/music-revenue';
+import type { Data, Summary } from '../../utils/components/widgets/widget-2';
 import {
   createDataForVisualization,
   createSummariesForCaptions,
-} from 'dummy/utils/components/widgets/widget-2';
+} from '../../utils/components/widgets/widget-2';
 
 interface WidgetsWidget2ComponentSignature {}
 

--- a/tests/dummy/app/components/widgets/widget-2/captions.ts
+++ b/tests/dummy/app/components/widgets/widget-2/captions.ts
@@ -1,7 +1,8 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import type { Summary } from 'dummy/utils/components/widgets/widget-2';
+
+import type { Summary } from '../../../utils/components/widgets/widget-2';
 
 interface WidgetsWidget2CaptionsComponentSignature {
   Args: {

--- a/tests/dummy/app/components/widgets/widget-2/stacked-chart.ts
+++ b/tests/dummy/app/components/widgets/widget-2/stacked-chart.ts
@@ -1,5 +1,6 @@
 import templateOnlyComponent from '@ember/component/template-only';
-import type { Data } from 'dummy/utils/components/widgets/widget-2';
+
+import type { Data } from '../../../utils/components/widgets/widget-2';
 
 interface WidgetsWidget2StackedChartComponentSignature {
   Args: {

--- a/tests/dummy/app/components/widgets/widget-3.ts
+++ b/tests/dummy/app/components/widgets/widget-3.ts
@@ -1,7 +1,8 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import type { Concert } from 'dummy/data/concert';
-import concertData from 'dummy/data/concert';
+
+import type { Concert } from '../../data/concert';
+import concertData from '../../data/concert';
 
 interface WidgetsWidget3ComponentSignature {}
 

--- a/tests/dummy/app/components/widgets/widget-3/tour-schedule.ts
+++ b/tests/dummy/app/components/widgets/widget-3/tour-schedule.ts
@@ -1,5 +1,6 @@
 import templateOnlyComponent from '@ember/component/template-only';
-import type { Concert } from 'dummy/data/concert';
+
+import type { Concert } from '../../../data/concert';
 
 export interface WidgetsWidget3TourScheduleComponentSignature {
   Args: {

--- a/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,9 +1,10 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import type { Image } from 'dummy/data/concert';
-import { findBestFittingImage } from 'dummy/utils/components/widgets/widget-3';
 import type { Dimensions } from 'ember-container-query/modifiers/container-query';
+
+import type { Image } from '../../../../data/concert';
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
 
 interface WidgetsWidget3TourScheduleResponsiveImageComponentSignature {
   Args: {

--- a/tests/dummy/app/modifiers/draw-stacked-chart.d.ts
+++ b/tests/dummy/app/modifiers/draw-stacked-chart.d.ts
@@ -1,5 +1,6 @@
 import { ModifierLike } from '@glint/template';
-import type { Data } from 'dummy/utils/components/widgets/widget-2';
+
+import type { Data } from '../utils/components/widgets/widget-2';
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {

--- a/tests/dummy/app/modifiers/draw-stacked-chart.js
+++ b/tests/dummy/app/modifiers/draw-stacked-chart.js
@@ -6,11 +6,12 @@ import { axisBottom, axisLeft } from 'd3-axis';
 import { scaleBand, scaleLinear, scaleOrdinal } from 'd3-scale';
 import { select } from 'd3-selection';
 import { stack, stackOrderReverse } from 'd3-shape';
+import Modifier from 'ember-modifier';
+
 import {
   COLOR_PALETTE,
   formatRevenue,
-} from 'dummy/utils/components/widgets/widget-2';
-import Modifier from 'ember-modifier';
+} from '../utils/components/widgets/widget-2';
 
 const musicFormats = Object.keys(COLOR_PALETTE);
 const paletteColors = Object.values(COLOR_PALETTE);

--- a/tests/dummy/app/router.ts
+++ b/tests/dummy/app/router.ts
@@ -1,5 +1,6 @@
 import EmberRouter from '@ember/routing/router';
-import config from 'dummy/config/environment';
+
+import config from './config/environment';
 
 export default class Router extends EmberRouter {
   location = config.locationType;

--- a/tests/dummy/app/routes/album.ts
+++ b/tests/dummy/app/routes/album.ts
@@ -1,7 +1,8 @@
 import Route from '@ember/routing/route';
-import type { Album } from 'dummy/data/album';
-import albumData from 'dummy/data/album';
-import type { ModelFrom } from 'dummy/utils/routes';
+
+import type { Album } from '../data/album';
+import albumData from '../data/album';
+import type { ModelFrom } from '../utils/routes';
 
 export default class AlbumRoute extends Route {
   model(): Album {

--- a/tests/dummy/app/utils/components/widgets/widget-2.ts
+++ b/tests/dummy/app/utils/components/widgets/widget-2.ts
@@ -1,4 +1,4 @@
-import type { Revenue } from 'dummy/data/music-revenue';
+import type { Revenue } from '../../../data/music-revenue';
 
 export type Data = {
   musicFormat: string;

--- a/tests/dummy/app/utils/components/widgets/widget-3.ts
+++ b/tests/dummy/app/utils/components/widgets/widget-3.ts
@@ -1,4 +1,4 @@
-import type { Image } from 'dummy/data/concert';
+import type { Image } from '../../../data/concert';
 
 export type ContainerDimensions = {
   aspectRatio: number;

--- a/tests/integration/components/container-query/dataAttributePrefix-test.ts
+++ b/tests/integration/components/container-query/dataAttributePrefix-test.ts
@@ -1,15 +1,16 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import type { CustomAssert } from 'dummy/tests/helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import type { CustomAssert } from '../../../helpers';
 import {
   resizeContainer,
   setupContainerQueryTest,
   setupRenderingTest,
   timeout,
-} from 'dummy/tests/helpers';
-import { hbs } from 'ember-cli-htmlbars';
-import { module, test } from 'qunit';
+} from '../../../helpers';
 
 interface TestContext extends BaseTestContext {
   dataAttributePrefix?: string;

--- a/tests/integration/components/container-query/debounce-test.ts
+++ b/tests/integration/components/container-query/debounce-test.ts
@@ -1,14 +1,15 @@
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import type { CustomAssert } from 'dummy/tests/helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import type { CustomAssert } from '../../../helpers';
 import {
   resizeContainer,
   setupContainerQueryTest,
   setupRenderingTest,
   timeout,
-} from 'dummy/tests/helpers';
-import { hbs } from 'ember-cli-htmlbars';
-import { module, test } from 'qunit';
+} from '../../../helpers';
 
 interface TestContext extends BaseTestContext {
   debounce?: number;

--- a/tests/integration/components/container-query/features-test.ts
+++ b/tests/integration/components/container-query/features-test.ts
@@ -1,16 +1,17 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import type { CustomAssert } from 'dummy/tests/helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import type { Features } from 'ember-container-query/modifiers/container-query';
+import { module, test } from 'qunit';
+
+import type { CustomAssert } from '../../../helpers';
 import {
   resizeContainer,
   setupContainerQueryTest,
   setupRenderingTest,
   timeout,
-} from 'dummy/tests/helpers';
-import { hbs } from 'ember-cli-htmlbars';
-import type { Features } from 'ember-container-query/modifiers/container-query';
-import { module, test } from 'qunit';
+} from '../../../helpers';
 
 type FeatureNames =
   | 'small'

--- a/tests/integration/components/container-query/splattributes-test.ts
+++ b/tests/integration/components/container-query/splattributes-test.ts
@@ -1,13 +1,14 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import type { CustomAssert } from 'dummy/tests/helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import type { CustomAssert } from '../../../helpers';
 import {
   setupContainerQueryTest,
   setupRenderingTest,
   timeout,
-} from 'dummy/tests/helpers';
-import { hbs } from 'ember-cli-htmlbars';
-import { module, test } from 'qunit';
+} from '../../../helpers';
 
 module('Integration | Component | container-query', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/container-query/tagName-test.ts
+++ b/tests/integration/components/container-query/tagName-test.ts
@@ -1,15 +1,16 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import type { CustomAssert } from 'dummy/tests/helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+
+import type { CustomAssert } from '../../../helpers';
 import {
   resizeContainer,
   setupContainerQueryTest,
   setupRenderingTest,
   timeout,
-} from 'dummy/tests/helpers';
-import { hbs } from 'ember-cli-htmlbars';
-import { module, test } from 'qunit';
+} from '../../../helpers';
 
 interface TestContext extends BaseTestContext {
   tagName?: string;

--- a/tests/integration/components/navigation-menu-test.ts
+++ b/tests/integration/components/navigation-menu-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { findAll, render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
 
 module('Integration | Component | navigation-menu', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/tracks-test.ts
+++ b/tests/integration/components/tracks-test.ts
@@ -2,9 +2,10 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
 import type { Album } from 'dummy/data/album';
 import albumData from 'dummy/data/album';
-import { resizeContainer, setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { resizeContainer, setupRenderingTest } from '../../helpers';
 
 interface TestContext extends BaseTestContext {
   album: Album;

--- a/tests/integration/components/tracks/list-test.ts
+++ b/tests/integration/components/tracks/list-test.ts
@@ -2,9 +2,10 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { findAll, render } from '@ember/test-helpers';
 import type { Track } from 'dummy/data/album';
 import albumData from 'dummy/data/album';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../helpers';
 
 type TrackProperties = {
   explicit: boolean;

--- a/tests/integration/components/tracks/table-test.ts
+++ b/tests/integration/components/tracks/table-test.ts
@@ -2,9 +2,10 @@ import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { findAll, render } from '@ember/test-helpers';
 import type { Track } from 'dummy/data/album';
 import albumData from 'dummy/data/album';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../helpers';
 
 type TrackProperties = {
   explicit: boolean;

--- a/tests/integration/components/ui/form-test.ts
+++ b/tests/integration/components/ui/form-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { find, render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../helpers';
 
 module('Integration | Component | ui/form', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/ui/form/checkbox-test.ts
+++ b/tests/integration/components/ui/form/checkbox-test.ts
@@ -1,9 +1,10 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { click, render, triggerKeyEvent } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../../helpers';
 
 interface TestContext extends BaseTestContext {
   changeset: Record<string, any>;

--- a/tests/integration/components/ui/form/field-test.ts
+++ b/tests/integration/components/ui/form/field-test.ts
@@ -1,9 +1,10 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { a11yAudit } from 'ember-a11y-testing/test-support';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../../helpers';
 
 module('Integration | Component | ui/form/field', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/ui/form/information-test.ts
+++ b/tests/integration/components/ui/form/information-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../../helpers';
 
 module('Integration | Component | ui/form/information', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/ui/form/input-test.ts
+++ b/tests/integration/components/ui/form/input-test.ts
@@ -1,9 +1,10 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { fillIn, render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../../helpers';
 
 interface TestContext extends BaseTestContext {
   changeset: Record<string, any>;

--- a/tests/integration/components/ui/form/textarea-test.ts
+++ b/tests/integration/components/ui/form/textarea-test.ts
@@ -1,9 +1,10 @@
 import { set } from '@ember/object';
 import type { TestContext as BaseTestContext } from '@ember/test-helpers';
 import { fillIn, render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../../helpers';
 
 interface TestContext extends BaseTestContext {
   changeset: Record<string, any>;

--- a/tests/integration/components/ui/page-test.ts
+++ b/tests/integration/components/ui/page-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../helpers';
 
 module('Integration | Component | ui/page', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/widgets/widget-1-test.ts
+++ b/tests/integration/components/widgets/widget-1-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { findAll, render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../helpers';
 
 module('Integration | Component | widgets/widget-1', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/widgets/widget-2-test.ts
+++ b/tests/integration/components/widgets/widget-2-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../helpers';
 
 module('Integration | Component | widgets/widget-2', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/widgets/widget-3-test.ts
+++ b/tests/integration/components/widgets/widget-3-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../helpers';
 
 module('Integration | Component | widgets/widget-3', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/widgets/widget-4-test.ts
+++ b/tests/integration/components/widgets/widget-4-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../helpers';
 
 module('Integration | Component | widgets/widget-4', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/widgets/widget-5-test.ts
+++ b/tests/integration/components/widgets/widget-5-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../../helpers';
 
 module('Integration | Component | widgets/widget-5', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/helpers/aspect-ratio-test.ts
+++ b/tests/integration/helpers/aspect-ratio-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
 
 module('Integration | Helper | aspect-ratio', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/helpers/cq-aspect-ratio-test.ts
+++ b/tests/integration/helpers/cq-aspect-ratio-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { getDeprecations, render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
 
 module('Integration | Helper | cq-aspect-ratio', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/helpers/cq-height-test.ts
+++ b/tests/integration/helpers/cq-height-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { getDeprecations, render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
 
 module('Integration | Helper | cq-height', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/helpers/cq-width-test.ts
+++ b/tests/integration/helpers/cq-width-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { getDeprecations, render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
 
 module('Integration | Helper | cq-width', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/helpers/height-test.ts
+++ b/tests/integration/helpers/height-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
 
 module('Integration | Helper | height', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/helpers/width-test.ts
+++ b/tests/integration/helpers/width-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
 
 module('Integration | Helper | width', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/modifiers/container-query-test.ts
+++ b/tests/integration/modifiers/container-query-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
 
 module('Integration | Modifier | container-query', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/modifiers/draw-stacked-chart-test.ts
+++ b/tests/integration/modifiers/draw-stacked-chart-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
 
 module('Integration | Modifier | draw-stacked-chart', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/modifiers/dynamic-css-grid-test.ts
+++ b/tests/integration/modifiers/dynamic-css-grid-test.ts
@@ -1,8 +1,9 @@
 import type { TestContext } from '@ember/test-helpers';
 import { render } from '@ember/test-helpers';
-import { setupRenderingTest } from 'dummy/tests/helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
+
+import { setupRenderingTest } from '../../helpers';
 
 module('Integration | Modifier | dynamic-css-grid', function (hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
## Description

I introduced relative paths for a couple of reasons:

- Remove the Ember magic that happens in import paths
- Prepare for v2 addon format, for which files will need to be moved around