### PR TITLE
Refactor types

### DIFF
--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -5,6 +5,8 @@ import { inject as service } from '@ember/service';
 import Modifier, { ArgsFor, NamedArgs, PositionalArgs } from 'ember-modifier';
 
 type IndexSignatureParameter = string | number | symbol;
+type ObjectEntry<T> = [keyof T, T[keyof T]];
+type ObjectEntries<T> = Array<ObjectEntry<T>>;
 
 type Dimensions = {
   aspectRatio: number;
@@ -131,11 +133,13 @@ export default class ContainerQueryModifier<
   private evaluateQueries(): void {
     const queryResults = {} as QueryResults<T>;
 
-    for (const [featureName, metadata] of Object.entries(this.features)) {
-      const { dimension, min, max } = metadata as Metadata;
+    for (const [featureName, metadata] of Object.entries(
+      this.features
+    ) as ObjectEntries<Features<T>>) {
+      const { dimension, min, max } = metadata;
       const value = this.dimensions[dimension];
 
-      queryResults[featureName as T] = min <= value && value < max;
+      queryResults[featureName] = min <= value && value < max;
     }
 
     this.queryResults = queryResults;
@@ -154,14 +158,14 @@ export default class ContainerQueryModifier<
 
     for (const [featureName, meetsFeature] of Object.entries(
       this.queryResults
-    )) {
+    ) as ObjectEntries<QueryResults<T>>) {
       if (!meetsFeature) {
         continue;
       }
 
       const dataAttribute = prefix
-        ? `data-${prefix}-${featureName}`
-        : `data-${featureName}`;
+        ? `data-${prefix}-${String(featureName)}`
+        : `data-${String(featureName)}`;
 
       element.setAttribute(dataAttribute, '');
 

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -51,7 +51,7 @@ export default class ContainerQueryModifier<
   dimensions!: Dimensions;
   queryResults!: QueryResults<T>;
 
-  private _dataAttributes: string[] = [];
+  private _dataAttributes: Array<string> = [];
   private _element?: Element;
   private _named!: NamedArgs<ContainerQueryModifierSignature<T>>;
 

--- a/addon/modifiers/container-query.ts
+++ b/addon/modifiers/container-query.ts
@@ -13,7 +13,7 @@ type Dimensions = {
 };
 
 type Metadata = {
-  dimension: 'aspectRatio' | 'height' | 'width';
+  dimension: keyof Dimensions;
   max: number;
   min: number;
 };


### PR DESCRIPTION
## Description

In commits 1 and 2, I updated the types of `metadata` and `Object.entries()` so that various pieces of the `{{container-query}}` modifier "work together" better. As a result, there is less need to cast types using the `as` keyword.

Commit 3 is a cosmetic change.


## References

- `ObjectEntry`: https://github.com/sindresorhus/type-fest/blob/v3.5.1/source/entry.d.ts#L6
- `ObjectEntries`: https://github.com/sindresorhus/type-fest/blob/v3.5.1/source/entries.d.ts#L5