### PR TITLE
Updated ember-modifier to v4

### DIFF
--- a/ember-container-query/package.json
+++ b/ember-container-query/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@embroider/addon-shim": "^1.8.4",
     "ember-element-helper": "^0.6.1",
-    "ember-modifier": "^3.2.7",
+    "ember-modifier": "^3.2.7 || ^4.0.0",
     "ember-resize-observer-service": "^1.1.0",
     "ember-test-selectors": "^6.0.0"
   },

--- a/ember-container-query/src/modifiers/container-query.ts
+++ b/ember-container-query/src/modifiers/container-query.ts
@@ -1,5 +1,6 @@
 import { registerDestructor } from '@ember/destroyable';
 import { action } from '@ember/object';
+import type Owner from '@ember/owner';
 import { debounce as _debounce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import Modifier, { ArgsFor, NamedArgs, PositionalArgs } from 'ember-modifier';
@@ -67,10 +68,7 @@ export default class ContainerQueryModifier<
     return this._named.features ?? ({} as Features<T>);
   }
 
-  constructor(
-    owner: unknown,
-    args: ArgsFor<ContainerQueryModifierSignature<T>>
-  ) {
+  constructor(owner: Owner, args: ArgsFor<ContainerQueryModifierSignature<T>>) {
     super(owner, args);
 
     registerDestructor(this, () => {

--- a/test-app/app/modifiers/dynamic-css-grid.ts
+++ b/test-app/app/modifiers/dynamic-css-grid.ts
@@ -17,8 +17,7 @@ const DynamicCssGridModifier = modifier<DynamicCssGridModifierSignature>(
 
     element.style.gridTemplateColumns = `repeat(${numColumns}, minmax(0, 1fr))`;
     element.style.gridTemplateRows = `repeat(${numRows}, 1fr)`;
-  },
-  { eager: false }
+  }
 );
 
 export default DynamicCssGridModifier;

--- a/test-app/config/ember-cli-update.json
+++ b/test-app/config/ember-cli-update.json
@@ -3,7 +3,7 @@
   "packages": [
     {
       "name": "ember-cli",
-      "version": "4.9.2",
+      "version": "4.10.0",
       "blueprints": [
         {
           "name": "app",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -102,6 +102,7 @@
     "ember-container-query": "4.0.0-alpha.2",
     "ember-css-modules": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
+    "ember-modifier": "^4.1.0",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^6.2.0",
     "ember-resolver": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5159,7 +5159,7 @@ ember-cli-typescript@^4.2.1:
     stagehand "^1.0.0"
     walk-sync "^2.2.0"
 
-ember-cli-typescript@^5.0.0, ember-cli-typescript@^5.2.1:
+ember-cli-typescript@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz#553030f1ce3e8958b8e4fc34909acd1218cb35f2"
   integrity sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==
@@ -5301,7 +5301,7 @@ ember-cli@~4.10.0:
     workerpool "^6.2.1"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.5:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz#b8363b1d5b8725afa9a4fe2b2986ac28626c6f23"
   integrity sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==
@@ -5357,16 +5357,14 @@ ember-load-initializers@^2.1.2:
     ember-cli-babel "^7.13.0"
     ember-cli-typescript "^2.0.2"
 
-ember-modifier@^3.2.7:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.7.tgz#f2d35b7c867cbfc549e1acd8d8903c5ecd02ea4b"
-  integrity sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==
+"ember-modifier@^3.2.7 || ^4.0.0", ember-modifier@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-4.1.0.tgz#cb91efbf8ca4ff4a1a859767afa42dddba5a2bbd"
+  integrity sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==
   dependencies:
-    ember-cli-babel "^7.26.6"
+    "@embroider/addon-shim" "^1.8.4"
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "^5.0.0"
-    ember-compatibility-helpers "^1.2.5"
 
 ember-page-title@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
## Description

Closes #143.

In case there are end-developers that use `ember-auto-import@v2` (a requirement for `v4` of this addon) but can't use `ember-modifier@v4`, I set the version of `ember-modifier` that is to be installed to `^3.2.7 || ^4.0.0`.

When I later drop support for `ember-modifier@v3.2.7`, I think that there won't be a major version release. That is, `v4` of this addon assumes `ember-modifier@v4` already.