### PR TITLE
Remove ember-test-selectors from dependencies

### DIFF
--- a/ember-container-query/package.json
+++ b/ember-container-query/package.json
@@ -59,8 +59,7 @@
     "@embroider/addon-shim": "^1.8.4",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7 || ^4.0.0",
-    "ember-resize-observer-service": "^1.1.0",
-    "ember-test-selectors": "^6.0.0"
+    "ember-resize-observer-service": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",

--- a/ember-container-query/src/components/container-query.hbs
+++ b/ember-container-query/src/components/container-query.hbs
@@ -2,7 +2,6 @@
 {{#let (element this.tagName) as |Tag|}}
   <Tag
     class="container-query"
-    data-test-container-query
     {{container-query
       dataAttributePrefix=@dataAttributePrefix
       debounce=@debounce

--- a/test-app/app/components/widgets/widget-1.hbs
+++ b/test-app/app/components/widgets/widget-1.hbs
@@ -5,6 +5,7 @@
     wide=(aspect-ratio min=1.25)
   }}
   @tagName="section"
+  data-test-container-query
   local-class="container"
 >
   <header local-class="header">

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -111,6 +111,7 @@
     "ember-svg-jar": "^2.4.2",
     "ember-template-lint": "^5.6.0",
     "ember-template-lint-plugin-prettier": "^4.1.0",
+    "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",
     "ember-try": "^2.0.0",
     "eslint": "^8.35.0",

--- a/test-app/tests/integration/components/container-query/dataAttributePrefix-test.ts
+++ b/test-app/tests/integration/components/container-query/dataAttributePrefix-test.ts
@@ -39,6 +39,7 @@ module('Integration | Component | container-query', function (hooks) {
               ratio-type-B=(aspect-ratio min=0.5 max=1.5)
               ratio-type-C=(aspect-ratio min=1.25 max=2)
             }}
+            data-test-container-query
             as |CQ|
           >
             <p data-test-feature="small">{{CQ.features.small}}</p>
@@ -138,6 +139,7 @@ module('Integration | Component | container-query', function (hooks) {
                 ratio-type-C=(aspect-ratio min=1.25 max=2)
               }}
               @dataAttributePrefix=""
+              data-test-container-query
               as |CQ|
             >
               <p data-test-feature="small">{{CQ.features.small}}</p>
@@ -238,6 +240,7 @@ module('Integration | Component | container-query', function (hooks) {
                 ratio-type-C=(aspect-ratio min=1.25 max=2)
               }}
               @dataAttributePrefix="cq"
+              data-test-container-query
               as |CQ|
             >
               <p data-test-feature="small">{{CQ.features.small}}</p>
@@ -338,6 +341,7 @@ module('Integration | Component | container-query', function (hooks) {
               ratio-type-C=(aspect-ratio min=1.25 max=2)
             }}
             @dataAttributePrefix={{this.dataAttributePrefix}}
+            data-test-container-query
             as |CQ|
           >
             <p data-test-feature="small">{{CQ.features.small}}</p>

--- a/test-app/tests/integration/components/container-query/debounce-test.ts
+++ b/test-app/tests/integration/components/container-query/debounce-test.ts
@@ -51,6 +51,7 @@ module('Integration | Component | container-query', function (hooks) {
               ratio-type-C=(aspect-ratio min=1.25 max=2)
             }}
             @debounce={{this.debounce}}
+            data-test-container-query
             as |CQ|
           >
             <p data-test-feature="small">{{CQ.features.small}}</p>

--- a/test-app/tests/integration/components/container-query/features-test.ts
+++ b/test-app/tests/integration/components/container-query/features-test.ts
@@ -44,6 +44,7 @@ module('Integration | Component | container-query', function (hooks) {
         >
           <ContainerQuery
             @features={{this.features}}
+            data-test-container-query
             as |CQ|
           >
             <p data-test-feature="small">{{CQ.features.small}}</p>
@@ -156,6 +157,7 @@ module('Integration | Component | container-query', function (hooks) {
               ratio-type-B=(aspect-ratio min=0.5 max=1.5)
               ratio-type-C=(aspect-ratio min=1.25 max=2)
             }}
+            data-test-container-query
             as |CQ|
           >
             <p data-test-feature="small">{{CQ.features.small}}</p>
@@ -283,6 +285,7 @@ module('Integration | Component | container-query', function (hooks) {
         >
           <ContainerQuery
             @features={{this.features}}
+            data-test-container-query
             as |CQ|
           >
             <p data-test-feature="small">{{CQ.features.small}}</p>

--- a/test-app/tests/integration/components/container-query/splattributes-test.ts
+++ b/test-app/tests/integration/components/container-query/splattributes-test.ts
@@ -31,6 +31,7 @@ module('Integration | Component | container-query', function (hooks) {
               ratio-type-C=(aspect-ratio min=1.25 max=2)
             }}
             class="unique-class-name"
+            data-test-container-query
             as |CQ|
           >
             <p data-test-feature="small">{{CQ.features.small}}</p>

--- a/test-app/tests/integration/components/container-query/tagName-test.ts
+++ b/test-app/tests/integration/components/container-query/tagName-test.ts
@@ -39,6 +39,7 @@ module('Integration | Component | container-query', function (hooks) {
               ratio-type-B=(aspect-ratio min=0.5 max=1.5)
               ratio-type-C=(aspect-ratio min=1.25 max=2)
             }}
+            data-test-container-query
             as |CQ|
           >
             <p data-test-feature="small">{{CQ.features.small}}</p>
@@ -108,6 +109,7 @@ module('Integration | Component | container-query', function (hooks) {
               ratio-type-C=(aspect-ratio min=1.25 max=2)
             }}
             @tagName="section"
+            data-test-container-query
             as |CQ|
           >
             <p data-test-feature="small">{{CQ.features.small}}</p>
@@ -179,6 +181,7 @@ module('Integration | Component | container-query', function (hooks) {
               ratio-type-C=(aspect-ratio min=1.25 max=2)
             }}
             @tagName={{this.tagName}}
+            data-test-container-query
             as |CQ|
           >
             <p data-test-feature="small">{{CQ.features.small}}</p>


### PR DESCRIPTION
## Background

Since [`v1.0.0`](https://github.com/ijlee2/ember-container-query/blob/1.0.0/addon/components/container-query.hbs#L3), the test selector `data-test-container-query` had been present to help me test the `<ContainerQuery>` component. By adding `ember-test-selectors` as a dependency, I had thought that _the test selector would be removed_ when the addon is consumed ([misunderstood the `README`](https://github.com/mainmatter/ember-test-selectors/tree/v6.0.0#usage-in-ember-addons)).

Since `ember-container-query` follows v2 addon format, I'd like to specify that `ember-test-selectors` is and has always been a development dependency for the `test-app` package.


## Migration Guide

If an end-developer consumed the test selector `data-test-container-query` directly for their tests, they will need to write the test selector explicitly:

```hbs
{{! Before }}
<ContainerQuery
  @feature={{hash ... }}
  as |CQ|
>
 ...
</ContainerQuery>

{{! After }}
<ContainerQuery
  @feature={{hash ... }}
  data-test-container-query
  as |CQ|
>
 ...
</ContainerQuery>
```

_However, testing the `<ContainerQuery>` component in the consuming project is not recommended._ The migration shown above happens to work because of splattributes, which were [to be used only for accessibility and styling](https://github.com/ijlee2/ember-container-query/tree/1.0.0#api). It's best if the consuming project trusts the component.