### PR TITLE
fix(docs): only process own styles as local

### DIFF
--- a/docs-app/ember-cli-build.js
+++ b/docs-app/ember-cli-build.js
@@ -34,7 +34,7 @@ module.exports = function (defaults) {
             // We want to enable local mode only for our own host app. All other
             // addons should be loaded in global mode.
             const hostAppWorkspaceDir = `${options.workspaceDir}/${app.name}`;
-            const isHostAppPath = resourcePath.startsWith(hostAppWorkspaceDir);
+            const isHostAppPath = resourcePath.includes(hostAppWorkspaceDir);
 
             return isHostAppPath ? 'local' : 'global';
           },

--- a/docs-app/ember-cli-build.js
+++ b/docs-app/ember-cli-build.js
@@ -18,15 +18,23 @@ module.exports = function (defaults) {
     },
   });
 
-  return require('@embroider/compat').compatBuild(app, Webpack, {
+  const options = {
     packagerOptions: {
       cssLoaderOptions: {
         modules: {
           localIdentName: isProduction()
             ? '[sha512:hash:base64:5]'
             : '[path][name]__[local]',
+          // Enable local mode only for CSS files from the host app
           mode: (resourcePath) => {
-            const isHostAppPath = resourcePath.includes(`/${app.name}/`);
+            // The host app and active child addons are moved into a common
+            // stable temp dir (`options.workspaceDir`), before the `css-loader`
+            // processes them.
+            //
+            // We want to enable local mode only for our own host app. All other
+            // addons should be loaded in global mode.
+            const hostAppWorkspaceDir = `${options.workspaceDir}/${app.name}`;
+            const isHostAppPath = resourcePath.startsWith(hostAppWorkspaceDir);
 
             return isHostAppPath ? 'local' : 'global';
           },
@@ -67,5 +75,7 @@ module.exports = function (defaults) {
     staticComponents: false, // due to ember-css-modules
     staticHelpers: true,
     staticModifiers: true,
-  });
+  };
+
+  return require('@embroider/compat').compatBuild(app, Webpack, options);
 };


### PR DESCRIPTION
This PR targets: #167

The embroider build pipeline in the target PR moves the host app and its active child addons into a common `workspaceDir`, which serves as a stable cache and unified file structure to enable the usage of advanced caching mechanisms offered by the packager (`webpack` in this case).

This becomes a problem, when trying to selectively apply [`cssLoaderOptions.modules.mode`](https://webpack.js.org/loaders/css-loader/#mode). In our scenario, we only want to apply `local` class names to the `*.css` files contained in the host app (`docs-app`). All other `*.css` files are not contained in the host app, but e.g. in addons that were moved into the common `workspaceDir`. They should remain in `global` mode.

Unfortunately the `mode` callback function only receives a single absolute `resourcePath` as argument, which looks like this:

- `/private/var/folders/zd/7ly06mpn2t512t2fr1g1ppw80000gq/T/embroider/5def33/docs-app/components/ui/form/textarea.css`
- `/private/var/folders/zd/7ly06mpn2t512t2fr1g1ppw80000gq/T/embroider/5def33/ember-container-query/dist/components/container-query.css`

These paths consist of three parts:

1. The leading static path segment is the `workspaceDir`:
   
    `/private/var/folders/zd/7ly06mpn2t512t2fr1g1ppw80000gq/T/embroider/5def33/`

2. It's followed by the package name of (either):

    - moved host app: `docs-app/`
    - moved addon dependencies: `ember-container-query/` _(...and potentially more addons)_
 
3. And lastly the package-internal file structure is preserved:

    - `components/ui/form/textarea.css`
    - `dist/components/container-query.css`

In order to reliably detect what package the `resourcePath` passed to `mode` belongs to, we need to know the `workspaceDir` prefix and package name of the host app to construct a path prefix by which we can filter.

Explicitly setting `workspaceDir` in the `options` object passed to `compatBuild` only works, if certain envrionment variables are set, which also change the build behavior. Instead we can rely on the default implementation which fortunately [assigns `options.workspaceDir`](https://github.com/embroider-build/embroider/blob/v1.8.3/packages/compat/src/default-pipeline.ts#L34-L41) _on the `options` argument_ that was passed.

Therefore, if we keep a local reference to `options` instead of anonymously passing the object literal inline to `compatBuild`, we can now access `options.workspaceDir`. Together with `app.name` we can build the full path prefix.

```js
const { Webpack } = require('@embroider/webpack');
const EmberApp = require('ember-cli/lib/broccoli/ember-app');

module.exports = function (defaults) {
  const app = new EmberApp(defaults, { /* ... */ });

  const options = {
    packagerOptions: {
      // Embroider lets us send our own options to the style-loader
      cssLoaderOptions: {
        // enable CSS modules
        modules: {
          // class naming template
          localIdentName: isProduction()
            ? '[sha512:hash:base64:5]'
            : '[path][name]__[local]',

          // only enable local mode for the host app itself
          mode(resourcePath) {
            // The host app and active child addons are moved into a common
            // stable temp dir (`options.workspaceDir`), before the `css-loader`
            // processes them.
            // We only want to enable local mode for our own host app. All other
            // addons should be loaded in global mode.
            const hostAppWorkspaceDir = `${options.workspaceDir}/${app.name}`;
            const isHostAppPath = resourcePath.startsWith(hostAppWorkspaceDir);

            return isHostAppPath ? 'local' : 'global';
          },
        },

        // don't create source maps in production
        sourceMap: !isProduction(),
      },
      // ...
    },
    // ...
  };

  return require('@embroider/compat').compatBuild(app, Webpack, options);
};
```

---

**Is this a good solution?**

Probably not, as it relies on `options.workspaceDir` being set (by reference), which is not explicitly documented AFAICT.

But it appears to work reasonably well so far.

**What would be a better approach?**

It would be great, if we could get public API access to the [`MovedPackageCache`](https://github.com/embroider-build/embroider/blob/v1.8.3/packages/compat/src/moved-package-cache.ts#L19-L28), or some simplified version of it to reduce the API surface area.