### PR TITLE
Renamed component signatures

### DIFF
--- a/docs-app/app/components/navigation-menu.ts
+++ b/docs-app/app/components/navigation-menu.ts
@@ -5,7 +5,7 @@ type MenuItem = {
   route: string;
 };
 
-interface NavigationMenuComponentSignature {
+interface NavigationMenuSignature {
   Args: {
     menuItems: MenuItem[];
     name?: string;
@@ -13,7 +13,7 @@ interface NavigationMenuComponentSignature {
 }
 
 const NavigationMenuComponent =
-  templateOnlyComponent<NavigationMenuComponentSignature>();
+  templateOnlyComponent<NavigationMenuSignature>();
 
 export default NavigationMenuComponent;
 

--- a/docs-app/app/components/products/product/card.ts
+++ b/docs-app/app/components/products/product/card.ts
@@ -2,7 +2,7 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 import type { Product } from '../../../data/products';
 
-interface ProductsProductCardComponentSignature {
+interface ProductsProductCardSignature {
   Args: {
     product: Product;
     redirectTo?: string;
@@ -10,7 +10,7 @@ interface ProductsProductCardComponentSignature {
 }
 
 const ProductsProductCardComponent =
-  templateOnlyComponent<ProductsProductCardComponentSignature>();
+  templateOnlyComponent<ProductsProductCardSignature>();
 
 export default ProductsProductCardComponent;
 

--- a/docs-app/app/components/products/product/image.ts
+++ b/docs-app/app/components/products/product/image.ts
@@ -1,13 +1,13 @@
 import Component from '@glimmer/component';
 import config from 'docs-app/config/environment';
 
-interface ProductsProductImageComponentSignature {
+interface ProductsProductImageSignature {
   Args: {
     src: string;
   };
 }
 
-export default class ProductsProductImageComponent extends Component<ProductsProductImageComponentSignature> {
+export default class ProductsProductImageComponent extends Component<ProductsProductImageSignature> {
   get isTestEnvironment() {
     return config.environment === 'test';
   }

--- a/docs-app/app/components/tracks.ts
+++ b/docs-app/app/components/tracks.ts
@@ -2,13 +2,13 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 import type { Track } from '../data/album';
 
-interface TracksComponentSignature {
+interface TracksSignature {
   Args: {
     tracks?: Track[];
   };
 }
 
-const TracksComponent = templateOnlyComponent<TracksComponentSignature>();
+const TracksComponent = templateOnlyComponent<TracksSignature>();
 
 export default TracksComponent;
 

--- a/docs-app/app/components/tracks/list.ts
+++ b/docs-app/app/components/tracks/list.ts
@@ -2,14 +2,14 @@ import Component from '@glimmer/component';
 
 import type { Track } from '../../data/album';
 
-interface TracksListComponentSignature {
+interface TracksListSignature {
   Args: {
     numColumns?: number;
     tracks?: Track[];
   };
 }
 
-export default class TracksListComponent extends Component<TracksListComponentSignature> {
+export default class TracksListComponent extends Component<TracksListSignature> {
   get numColumns(): number {
     const { numColumns } = this.args;
 

--- a/docs-app/app/components/tracks/table.ts
+++ b/docs-app/app/components/tracks/table.ts
@@ -2,14 +2,14 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 import type { Track } from '../../data/album';
 
-interface TracksTableComponentSignature {
+interface TracksTableSignature {
   Args: {
     tracks?: Track[];
   };
 }
 
 const TracksTableComponent =
-  templateOnlyComponent<TracksTableComponentSignature>();
+  templateOnlyComponent<TracksTableSignature>();
 
 export default TracksTableComponent;
 

--- a/docs-app/app/components/tracks/table.ts
+++ b/docs-app/app/components/tracks/table.ts
@@ -8,8 +8,7 @@ interface TracksTableSignature {
   };
 }
 
-const TracksTableComponent =
-  templateOnlyComponent<TracksTableSignature>();
+const TracksTableComponent = templateOnlyComponent<TracksTableSignature>();
 
 export default TracksTableComponent;
 

--- a/docs-app/app/components/ui/form.ts
+++ b/docs-app/app/components/ui/form.ts
@@ -8,7 +8,7 @@ import type UiFormCheckboxComponent from './form/checkbox';
 import type UiFormInputComponent from './form/input';
 import type UiFormTextareaComponent from './form/textarea';
 
-interface UiFormComponentSignature {
+interface UiFormSignature {
   Args: {
     data?: Record<string, any>;
     instructions?: string;
@@ -34,7 +34,7 @@ interface UiFormComponentSignature {
   };
 }
 
-export default class UiFormComponent extends Component<UiFormComponentSignature> {
+export default class UiFormComponent extends Component<UiFormSignature> {
   formId = guidFor(this);
 
   @tracked changeset = this.args.data ?? ({} as Record<string, any>);

--- a/docs-app/app/components/ui/form/checkbox.ts
+++ b/docs-app/app/components/ui/form/checkbox.ts
@@ -1,7 +1,7 @@
 import { action, get } from '@ember/object';
 import Component from '@glimmer/component';
 
-interface UiFormCheckboxComponentSignature {
+interface UiFormCheckboxSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -15,7 +15,7 @@ interface UiFormCheckboxComponentSignature {
   };
 }
 
-export default class UiFormCheckboxComponent extends Component<UiFormCheckboxComponentSignature> {
+export default class UiFormCheckboxComponent extends Component<UiFormCheckboxSignature> {
   get errorMessage(): string | undefined {
     const { isRequired } = this.args;
 

--- a/docs-app/app/components/ui/form/field.ts
+++ b/docs-app/app/components/ui/form/field.ts
@@ -1,7 +1,7 @@
 import { guidFor } from '@ember/object/internals';
 import Component from '@glimmer/component';
 
-interface UiFormFieldComponentSignature {
+interface UiFormFieldSignature {
   Args: {
     errorMessage?: string;
     isInline?: boolean;
@@ -21,7 +21,7 @@ interface UiFormFieldComponentSignature {
   };
 }
 
-export default class UiFormFieldComponent extends Component<UiFormFieldComponentSignature> {
+export default class UiFormFieldComponent extends Component<UiFormFieldSignature> {
   inputId = guidFor(this);
 }
 

--- a/docs-app/app/components/ui/form/information.ts
+++ b/docs-app/app/components/ui/form/information.ts
@@ -1,6 +1,6 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface UiFormInformationComponentSignature {
+interface UiFormInformationSignature {
   Args: {
     formId: string;
     instructions?: string;
@@ -9,7 +9,7 @@ interface UiFormInformationComponentSignature {
 }
 
 const UiFormInformationComponent =
-  templateOnlyComponent<UiFormInformationComponentSignature>();
+  templateOnlyComponent<UiFormInformationSignature>();
 
 export default UiFormInformationComponent;
 

--- a/docs-app/app/components/ui/form/input.ts
+++ b/docs-app/app/components/ui/form/input.ts
@@ -1,7 +1,7 @@
 import { action, get } from '@ember/object';
 import Component from '@glimmer/component';
 
-interface UiFormInputComponentSignature {
+interface UiFormInputSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -16,7 +16,7 @@ interface UiFormInputComponentSignature {
   };
 }
 
-export default class UiFormInputComponent extends Component<UiFormInputComponentSignature> {
+export default class UiFormInputComponent extends Component<UiFormInputSignature> {
   get errorMessage(): string | undefined {
     const { isRequired } = this.args;
 

--- a/docs-app/app/components/ui/form/textarea.ts
+++ b/docs-app/app/components/ui/form/textarea.ts
@@ -1,7 +1,7 @@
 import { action, get } from '@ember/object';
 import Component from '@glimmer/component';
 
-interface UiFormTextareaComponentSignature {
+interface UiFormTextareaSignature {
   Args: {
     changeset: Record<string, any>;
     isDisabled?: boolean;
@@ -15,7 +15,7 @@ interface UiFormTextareaComponentSignature {
   };
 }
 
-export default class UiFormTextareaComponent extends Component<UiFormTextareaComponentSignature> {
+export default class UiFormTextareaComponent extends Component<UiFormTextareaSignature> {
   get errorMessage(): string | undefined {
     const { isRequired } = this.args;
 

--- a/docs-app/app/components/ui/page.ts
+++ b/docs-app/app/components/ui/page.ts
@@ -1,6 +1,6 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface UiPageComponentSignature {
+interface UiPageSignature {
   Args: {
     title: string;
   };
@@ -9,7 +9,7 @@ interface UiPageComponentSignature {
   };
 }
 
-const UiPageComponent = templateOnlyComponent<UiPageComponentSignature>();
+const UiPageComponent = templateOnlyComponent<UiPageSignature>();
 
 export default UiPageComponent;
 

--- a/docs-app/app/components/widgets/widget-1.ts
+++ b/docs-app/app/components/widgets/widget-1.ts
@@ -1,9 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget1ComponentSignature {}
+interface WidgetsWidget1Signature {}
 
 const WidgetsWidget1Component =
-  templateOnlyComponent<WidgetsWidget1ComponentSignature>();
+  templateOnlyComponent<WidgetsWidget1Signature>();
 
 export default WidgetsWidget1Component;
 

--- a/docs-app/app/components/widgets/widget-1/item.ts
+++ b/docs-app/app/components/widgets/widget-1/item.ts
@@ -1,13 +1,13 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget1ItemComponentSignature {
+interface WidgetsWidget1ItemSignature {
   Args: {
     title: string;
   };
 }
 
 const WidgetsWidget1ItemComponent =
-  templateOnlyComponent<WidgetsWidget1ItemComponentSignature>();
+  templateOnlyComponent<WidgetsWidget1ItemSignature>();
 
 export default WidgetsWidget1ItemComponent;
 

--- a/docs-app/app/components/widgets/widget-2.ts
+++ b/docs-app/app/components/widgets/widget-2.ts
@@ -8,16 +8,16 @@ import {
   createSummariesForCaptions,
 } from '../../utils/components/widgets/widget-2';
 
-interface WidgetsWidget2ComponentSignature {
+interface WidgetsWidget2Signature {
   // eslint-disable-next-line @typescript-eslint/ban-types
   Args: {};
 }
 
-export default class WidgetsWidget2Component extends Component<WidgetsWidget2ComponentSignature> {
+export default class WidgetsWidget2Component extends Component<WidgetsWidget2Signature> {
   @tracked data = [] as Data[];
   @tracked summaries = [] as Summary[];
 
-  constructor(owner: unknown, args: WidgetsWidget2ComponentSignature['Args']) {
+  constructor(owner: unknown, args: WidgetsWidget2Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/docs-app/app/components/widgets/widget-2/captions.ts
+++ b/docs-app/app/components/widgets/widget-2/captions.ts
@@ -4,13 +4,13 @@ import { tracked } from '@glimmer/tracking';
 
 import type { Summary } from '../../../utils/components/widgets/widget-2';
 
-interface WidgetsWidget2CaptionsComponentSignature {
+interface WidgetsWidget2CaptionsSignature {
   Args: {
     summaries?: Summary[];
   };
 }
 
-export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsComponentSignature> {
+export default class WidgetsWidget2CaptionsComponent extends Component<WidgetsWidget2CaptionsSignature> {
   @tracked currentIndex = 0;
 
   get canShowNextButton(): boolean {

--- a/docs-app/app/components/widgets/widget-2/stacked-chart.ts
+++ b/docs-app/app/components/widgets/widget-2/stacked-chart.ts
@@ -2,14 +2,14 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 import type { Data } from '../../../utils/components/widgets/widget-2';
 
-interface WidgetsWidget2StackedChartComponentSignature {
+interface WidgetsWidget2StackedChartSignature {
   Args: {
     data: Data[];
   };
 }
 
 const WidgetsWidget2StackedChartComponent =
-  templateOnlyComponent<WidgetsWidget2StackedChartComponentSignature>();
+  templateOnlyComponent<WidgetsWidget2StackedChartSignature>();
 
 export default WidgetsWidget2StackedChartComponent;
 

--- a/docs-app/app/components/widgets/widget-3.ts
+++ b/docs-app/app/components/widgets/widget-3.ts
@@ -4,15 +4,15 @@ import { tracked } from '@glimmer/tracking';
 import type { Concert } from '../../data/concert';
 import concertData from '../../data/concert';
 
-interface WidgetsWidget3ComponentSignature {
+interface WidgetsWidget3Signature {
   // eslint-disable-next-line @typescript-eslint/ban-types
   Args: {};
 }
 
-export default class WidgetsWidget3Component extends Component<WidgetsWidget3ComponentSignature> {
+export default class WidgetsWidget3Component extends Component<WidgetsWidget3Signature> {
   @tracked concertData = {} as Concert;
 
-  constructor(owner: unknown, args: WidgetsWidget3ComponentSignature['Args']) {
+  constructor(owner: unknown, args: WidgetsWidget3Signature['Args']) {
     super(owner, args);
 
     this.loadData();

--- a/docs-app/app/components/widgets/widget-3/tour-schedule.ts
+++ b/docs-app/app/components/widgets/widget-3/tour-schedule.ts
@@ -2,14 +2,14 @@ import templateOnlyComponent from '@ember/component/template-only';
 
 import type { Concert } from '../../../data/concert';
 
-interface WidgetsWidget3TourScheduleComponentSignature {
+interface WidgetsWidget3TourScheduleSignature {
   Args: {
     concert: Concert;
   };
 }
 
 const WidgetsWidget3TourScheduleComponent =
-  templateOnlyComponent<WidgetsWidget3TourScheduleComponentSignature>();
+  templateOnlyComponent<WidgetsWidget3TourScheduleSignature>();
 
 export default WidgetsWidget3TourScheduleComponent;
 

--- a/docs-app/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/docs-app/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -6,13 +6,13 @@ import type { Dimensions } from 'ember-container-query/modifiers/container-query
 import type { Image } from '../../../../data/concert';
 import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
 
-interface WidgetsWidget3TourScheduleResponsiveImageComponentSignature {
+interface WidgetsWidget3TourScheduleResponsiveImageSignature {
   Args: {
     images: Image[];
   };
 }
 
-export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentSignature> {
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageSignature> {
   @tracked imageSource?: string;
 
   @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {

--- a/docs-app/app/components/widgets/widget-4.ts
+++ b/docs-app/app/components/widgets/widget-4.ts
@@ -1,9 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget4ComponentSignature {}
+interface WidgetsWidget4Signature {}
 
 const WidgetsWidget4Component =
-  templateOnlyComponent<WidgetsWidget4ComponentSignature>();
+  templateOnlyComponent<WidgetsWidget4Signature>();
 
 export default WidgetsWidget4Component;
 

--- a/docs-app/app/components/widgets/widget-4/memo.ts
+++ b/docs-app/app/components/widgets/widget-4/memo.ts
@@ -1,9 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget4MemoComponentSignature {}
+interface WidgetsWidget4MemoSignature {}
 
 const WidgetsWidget4MemoComponent =
-  templateOnlyComponent<WidgetsWidget4MemoComponentSignature>();
+  templateOnlyComponent<WidgetsWidget4MemoSignature>();
 
 export default WidgetsWidget4MemoComponent;
 

--- a/docs-app/app/components/widgets/widget-4/memo/actions.ts
+++ b/docs-app/app/components/widgets/widget-4/memo/actions.ts
@@ -1,13 +1,13 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget4MemoActionsComponentSignature {
+interface WidgetsWidget4MemoActionsSignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
 const WidgetsWidget4MemoActionsComponent =
-  templateOnlyComponent<WidgetsWidget4MemoActionsComponentSignature>();
+  templateOnlyComponent<WidgetsWidget4MemoActionsSignature>();
 
 export default WidgetsWidget4MemoActionsComponent;
 

--- a/docs-app/app/components/widgets/widget-4/memo/body.ts
+++ b/docs-app/app/components/widgets/widget-4/memo/body.ts
@@ -1,13 +1,13 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget4MemoBodyComponentSignature {
+interface WidgetsWidget4MemoBodySignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
 const WidgetsWidget4MemoBodyComponent =
-  templateOnlyComponent<WidgetsWidget4MemoBodyComponentSignature>();
+  templateOnlyComponent<WidgetsWidget4MemoBodySignature>();
 
 export default WidgetsWidget4MemoBodyComponent;
 

--- a/docs-app/app/components/widgets/widget-4/memo/header.ts
+++ b/docs-app/app/components/widgets/widget-4/memo/header.ts
@@ -1,13 +1,13 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget4MemoHeaderComponentSignature {
+interface WidgetsWidget4MemoHeaderSignature {
   Args: {
     cqFeatures?: Record<'small' | 'large' | 'short', boolean>;
   };
 }
 
 const WidgetsWidget4MemoHeaderComponent =
-  templateOnlyComponent<WidgetsWidget4MemoHeaderComponentSignature>();
+  templateOnlyComponent<WidgetsWidget4MemoHeaderSignature>();
 
 export default WidgetsWidget4MemoHeaderComponent;
 

--- a/docs-app/app/components/widgets/widget-5.ts
+++ b/docs-app/app/components/widgets/widget-5.ts
@@ -1,9 +1,9 @@
 import templateOnlyComponent from '@ember/component/template-only';
 
-interface WidgetsWidget5ComponentSignature {}
+interface WidgetsWidget5Signature {}
 
 const WidgetsWidget5Component =
-  templateOnlyComponent<WidgetsWidget5ComponentSignature>();
+  templateOnlyComponent<WidgetsWidget5Signature>();
 
 export default WidgetsWidget5Component;
 

--- a/ember-container-query/src/components/container-query.ts
+++ b/ember-container-query/src/components/container-query.ts
@@ -11,7 +11,7 @@ import type {
   QueryResults,
 } from '../modifiers/container-query';
 
-interface ContainerQueryComponentSignature<T extends IndexSignatureParameter> {
+interface ContainerQuerySignature<T extends IndexSignatureParameter> {
   Args: {
     dataAttributePrefix?: string;
     debounce?: number;
@@ -31,7 +31,7 @@ interface ContainerQueryComponentSignature<T extends IndexSignatureParameter> {
 
 export default class ContainerQueryComponent<
   T extends IndexSignatureParameter
-> extends Component<ContainerQueryComponentSignature<T>> {
+> extends Component<ContainerQuerySignature<T>> {
   @tracked dimensions?: Dimensions;
   @tracked queryResults?: QueryResults<T>;
 


### PR DESCRIPTION
## Description

Until now, I have been appending the word `Signature` to the component name, which ends in `Component`. I noticed that `ember-source@v4.12.0` introduced a naming convention for component signatures:

```ts
/* app/components/navigation-menu.ts */
interface NavigationMenuSignature {
  ...
}
```

https://github.com/emberjs/ember.js/blob/v4.12.0/blueprints/component/index.js#L318