### PR TITLE
Updated configuration files to match Ember v4.12 blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,21 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
-
 # compiled output
 /dist/
-/tmp/
 
 # dependencies
-/bower_components/
 /node_modules/
 
 # misc
 /.env*
 /.pnp*
-/.sass-cache
 /.eslintcache
-/connect.lock
+/.stylelintcache
 /coverage/
-/libpeerconnection.log
 /npm-debug.log*
 /testem.log
 /yarn-error.log
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
 /npm-shrinkwrap.json.ember-try
 /package.json.ember-try
 /package-lock.json.ember-try

--- a/docs-app/.ember-cli
+++ b/docs-app/.ember-cli
@@ -11,5 +11,5 @@
     Setting `isTypeScriptProject` to true will force the blueprint generators to generate TypeScript
     rather than JavaScript by default, when a TypeScript version of a given blueprint is available.
   */
-  "isTypeScriptProject": false
+  "isTypeScriptProject": true
 }

--- a/docs-app/.eslintignore
+++ b/docs-app/.eslintignore
@@ -1,25 +1,13 @@
 # unconventional js
 /blueprints/*/files/
-/vendor/
 
 # compiled output
 /dist/
-/tmp/
-
-# dependencies
-/bower_components/
-/node_modules/
 
 # misc
 /coverage/
 !.*
 .*/
-.eslintcache
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
-/package.json.ember-try
-/package-lock.json.ember-try
-/yarn.lock.ember-try

--- a/docs-app/.gitignore
+++ b/docs-app/.gitignore
@@ -1,30 +1,21 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
-
 # compiled output
 /dist/
-/tmp/
 
 # dependencies
-/bower_components/
 /node_modules/
 
 # misc
 /.env*
 /.pnp*
-/.DS_Store
-/.sass-cache
 /.eslintcache
 /.stylelintcache
-/connect.lock
 /coverage/
-/libpeerconnection.log
 /npm-debug.log*
 /testem.log
 /yarn-error.log
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
 /npm-shrinkwrap.json.ember-try
 /package.json.ember-try
 /package-lock.json.ember-try

--- a/docs-app/.prettierignore
+++ b/docs-app/.prettierignore
@@ -1,28 +1,13 @@
 # unconventional js
 /blueprints/*/files/
-/vendor/
 
 # compiled output
 /dist/
-/tmp/
-
-# dependencies
-/bower_components/
-/node_modules/
 
 # misc
 /coverage/
 !.*
-.eslintcache
-.lint-todo/
-
-# ember-try
-/.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
-/package.json.ember-try
-/package-lock.json.ember-try
-/yarn.lock.ember-try
+.*/
 
 # ember-template-imports
 /**/*.gjs

--- a/docs-app/.watchmanconfig
+++ b/docs-app/.watchmanconfig
@@ -1,3 +1,3 @@
 {
-  "ignore_dirs": ["tmp", "dist"]
+  "ignore_dirs": ["dist"]
 }

--- a/ember-container-query/.eslintignore
+++ b/ember-container-query/.eslintignore
@@ -6,3 +6,5 @@
 
 # misc
 /coverage/
+!.*
+.*/

--- a/ember-container-query/.eslintrc.js
+++ b/ember-container-query/.eslintrc.js
@@ -4,7 +4,8 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 'latest',
+    sourceType: 'module',
   },
   plugins: [
     'ember',

--- a/ember-container-query/.gitignore
+++ b/ember-container-query/.gitignore
@@ -1,30 +1,21 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
-
 # compiled output
 /dist/
-/tmp/
 
 # dependencies
-/bower_components/
 /node_modules/
 
 # misc
 /.env*
 /.pnp*
-/.DS_Store
-/.sass-cache
 /.eslintcache
 /.stylelintcache
-/connect.lock
 /coverage/
-/libpeerconnection.log
 /npm-debug.log*
 /testem.log
 /yarn-error.log
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
 /npm-shrinkwrap.json.ember-try
 /package.json.ember-try
 /package-lock.json.ember-try

--- a/ember-container-query/.prettierignore
+++ b/ember-container-query/.prettierignore
@@ -1,25 +1,10 @@
 # unconventional js
 /blueprints/*/files/
-/vendor/
 
 # compiled output
 /dist/
-/tmp/
-
-# dependencies
-/bower_components/
-/node_modules/
 
 # misc
 /coverage/
 !.*
-.eslintcache
-.lint-todo/
-
-# ember-try
-/.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
-/package.json.ember-try
-/package-lock.json.ember-try
-/yarn.lock.ember-try
+.*/

--- a/test-app/.ember-cli
+++ b/test-app/.ember-cli
@@ -11,5 +11,5 @@
     Setting `isTypeScriptProject` to true will force the blueprint generators to generate TypeScript
     rather than JavaScript by default, when a TypeScript version of a given blueprint is available.
   */
-  "isTypeScriptProject": false
+  "isTypeScriptProject": true
 }

--- a/test-app/.eslintignore
+++ b/test-app/.eslintignore
@@ -1,25 +1,13 @@
 # unconventional js
 /blueprints/*/files/
-/vendor/
 
 # compiled output
 /dist/
-/tmp/
-
-# dependencies
-/bower_components/
-/node_modules/
 
 # misc
 /coverage/
 !.*
 .*/
-.eslintcache
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
-/package.json.ember-try
-/package-lock.json.ember-try
-/yarn.lock.ember-try

--- a/test-app/.gitignore
+++ b/test-app/.gitignore
@@ -1,30 +1,21 @@
-# See https://help.github.com/ignore-files/ for more about ignoring files.
-
 # compiled output
 /dist/
-/tmp/
 
 # dependencies
-/bower_components/
 /node_modules/
 
 # misc
 /.env*
 /.pnp*
-/.DS_Store
-/.sass-cache
 /.eslintcache
 /.stylelintcache
-/connect.lock
 /coverage/
-/libpeerconnection.log
 /npm-debug.log*
 /testem.log
 /yarn-error.log
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
 /npm-shrinkwrap.json.ember-try
 /package.json.ember-try
 /package-lock.json.ember-try

--- a/test-app/.prettierignore
+++ b/test-app/.prettierignore
@@ -1,25 +1,13 @@
 # unconventional js
 /blueprints/*/files/
-/vendor/
 
 # compiled output
 /dist/
-/tmp/
-
-# dependencies
-/bower_components/
-/node_modules/
 
 # misc
 /coverage/
 !.*
-.eslintcache
-.lint-todo/
+.*/
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
-/package.json.ember-try
-/package-lock.json.ember-try
-/yarn.lock.ember-try

--- a/test-app/.watchmanconfig
+++ b/test-app/.watchmanconfig
@@ -1,3 +1,3 @@
 {
-  "ignore_dirs": ["tmp", "dist"]
+  "ignore_dirs": ["dist"]
 }


### PR DESCRIPTION
## Description

Various configuration files have been updated in Ember `v4.12`. Now is a good time update `docs-app` and `test-app` to match the blueprints.


## References

- https://github.com/ember-cli/ember-cli/pull/10229
- https://github.com/ember-cli/ember-cli/pull/10178