### PR TITLE
Generalized how webpack checks if a stylesheet comes from us (host app) or them (some package)

### DIFF
--- a/docs-app/ember-cli-build.js
+++ b/docs-app/ember-cli-build.js
@@ -25,18 +25,16 @@ module.exports = function (defaults) {
           localIdentName: isProduction()
             ? '[sha512:hash:base64:5]'
             : '[path][name]__[local]',
-          // Enable local mode only for CSS files from the host app
           mode: (resourcePath) => {
-            // The host app and active child addons are moved into a common
-            // stable temp dir (`options.workspaceDir`), before the `css-loader`
+            // The host app and active child addons are moved into a shared
+            // temporary directory (`options.workspaceDir`) before css-loader
             // processes them.
             //
-            // We want to enable local mode only for our own host app. All other
-            // addons should be loaded in global mode.
-            const hostAppWorkspaceDir = `${options.workspaceDir}/${app.name}`;
-            const isHostAppPath = resourcePath.includes(hostAppWorkspaceDir);
+            // We want to enable the local mode only for our own host app.
+            // All other addons should be loaded in the global mode.
+            const hostAppLocation = `${options.workspaceDir}/docs-app`;
 
-            return isHostAppPath ? 'local' : 'global';
+            return resourcePath.includes(hostAppLocation) ? 'local' : 'global';
           },
         },
         sourceMap: !isProduction(),


### PR DESCRIPTION
## Description

While working on https://github.com/ijlee2/embroider-css-modules/pull/30, I realized that the current webpack implementation for CSS modules is incorrect under one of these conditions:

- The package name is different from the package location.
- The package is a part of workspaces (i.e. in some subfolder).

At the moment, I don't think Embroider provides a public API, with which we can easily determine if a stylesheet belongs to "us" (the host app) or "them" (some package that we installed).

The only reliable and easy solution that I could think of was (for the end-developer) to hardcode the package location.

```js
/*
  Example 1 (from ember-container-query)

  - The app is named `docs-app`.
  - The app lives inside the folder also named `docs-app`.
*/
function mode(resourcePath) {
  const hostAppLocation = `${options.workspaceDir}/docs-app`;

  return resourcePath.includes(hostAppLocation) ? 'local' : 'global';
}

/*
  Example 2 (from embroider-css-modules)

  - The app is named `docs-app-for-embroider-css-modules`.
  - The app lives inside the folder `docs/embroider-css-modules`.
*/
function mode(resourcePath) {
  const hostAppLocation = `${options.workspaceDir}/docs/embroider-css-modules`;

  return resourcePath.includes(hostAppLocation) ? 'local' : 'global';
}
```

Related PR: https://github.com/ijlee2/embroider-css-modules/pull/31