### PR TITLE
Addressed syntax deprecation from @babel/plugin-proposal-decorators

### DIFF
--- a/ember-container-query/babel.config.json
+++ b/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }


### PR DESCRIPTION
## Description

According to [Babel](https://babeljs.io/docs/babel-plugin-proposal-decorators#legacy), the syntax `{ "legacy": true }` has been deprecated.

> Use version: "legacy" instead. This option is a legacy alias.

The pull request tests the change introduced to v2 addons in https://github.com/ijlee2/ember-codemod-v1-to-v2/pull/36.