### PR TITLE
Downstreamed bug fix from @embroider/addon-blueprint#155

### DIFF
--- a/ember-container-query/package.json
+++ b/ember-container-query/package.json
@@ -84,7 +84,6 @@
     "@glint/environment-ember-loose": "^1.0.2",
     "@glint/template": "^1.0.2",
     "@rollup/plugin-babel": "^6.0.3",
-    "@rollup/plugin-node-resolve": "^15.1.0",
     "@tsconfig/ember": "^2.0.0",
     "@types/ember__component": "^4.0.14",
     "@types/ember__destroyable": "^4.0.2",

--- a/ember-container-query/rollup.config.mjs
+++ b/ember-container-query/rollup.config.mjs
@@ -1,6 +1,5 @@
 import { Addon } from '@embroider/addon-dev/rollup';
 import { babel } from '@rollup/plugin-babel';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 import copy from 'rollup-plugin-copy';
 
 const addon = new Addon({
@@ -53,11 +52,6 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions,
-    }),
-
-    // Allows rollup to resolve imports of files with the specified extensions
-    nodeResolve({
       extensions,
     }),
 

--- a/ember-container-query/src/components/container-query.ts
+++ b/ember-container-query/src/components/container-query.ts
@@ -9,7 +9,7 @@ import type {
   Features,
   IndexSignatureParameter,
   QueryResults,
-} from '../modifiers/container-query';
+} from '../modifiers/container-query.ts';
 
 interface ContainerQuerySignature<T extends IndexSignatureParameter> {
   Args: {

--- a/ember-container-query/src/helpers/aspect-ratio.ts
+++ b/ember-container-query/src/helpers/aspect-ratio.ts
@@ -1,6 +1,6 @@
 import { helper } from '@ember/component/helper';
 
-import type { Metadata } from '../modifiers/container-query';
+import type { Metadata } from '../modifiers/container-query.ts';
 
 interface AspectRatioHelperSignature {
   Args: {

--- a/ember-container-query/src/helpers/height.ts
+++ b/ember-container-query/src/helpers/height.ts
@@ -1,6 +1,6 @@
 import { helper } from '@ember/component/helper';
 
-import type { Metadata } from '../modifiers/container-query';
+import type { Metadata } from '../modifiers/container-query.ts';
 
 interface HeightHelperSignature {
   Args: {

--- a/ember-container-query/src/helpers/width.ts
+++ b/ember-container-query/src/helpers/width.ts
@@ -1,6 +1,6 @@
 import { helper } from '@ember/component/helper';
 
-import type { Metadata } from '../modifiers/container-query';
+import type { Metadata } from '../modifiers/container-query.ts';
 
 interface WidthHelperSignature {
   Args: {

--- a/ember-container-query/src/index.ts
+++ b/ember-container-query/src/index.ts
@@ -1,12 +1,12 @@
-export { default as ContainerQuery } from './components/container-query';
-export { default as aspectRatio } from './helpers/aspect-ratio';
-export { default as height } from './helpers/height';
-export { default as width } from './helpers/width';
+export { default as ContainerQuery } from './components/container-query.ts';
+export { default as aspectRatio } from './helpers/aspect-ratio.ts';
+export { default as height } from './helpers/height.ts';
+export { default as width } from './helpers/width.ts';
 export type {
   Dimensions,
   Features,
   IndexSignatureParameter,
   Metadata,
   QueryResults,
-} from './modifiers/container-query';
-export { default as containerQuery } from './modifiers/container-query';
+} from './modifiers/container-query.ts';
+export { default as containerQuery } from './modifiers/container-query.ts';

--- a/ember-container-query/src/template-registry.ts
+++ b/ember-container-query/src/template-registry.ts
@@ -1,8 +1,8 @@
-import type ContainerQueryComponent from './components/container-query';
-import type AspectRatioHelper from './helpers/aspect-ratio';
-import type HeightHelper from './helpers/height';
-import type WidthHelper from './helpers/width';
-import type ContainerQueryModifier from './modifiers/container-query';
+import type ContainerQueryComponent from './components/container-query.ts';
+import type AspectRatioHelper from './helpers/aspect-ratio.ts';
+import type HeightHelper from './helpers/height.ts';
+import type WidthHelper from './helpers/width.ts';
+import type ContainerQueryModifier from './modifiers/container-query.ts';
 
 export default interface EmberContainerQueryRegistry {
   ContainerQuery: typeof ContainerQueryComponent;

--- a/ember-container-query/tsconfig.json
+++ b/ember-container-query/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declarationDir": "declarations",
     "skipLibCheck": true
   },

--- a/ember-container-query/unpublished-development-types/index.d.ts
+++ b/ember-container-query/unpublished-development-types/index.d.ts
@@ -5,7 +5,7 @@ import '@glint/environment-ember-loose';
 
 import { ComponentLike, HelperLike } from '@glint/template';
 
-import EmberContainerQueryRegistry from '../src/template-registry';
+import type EmberContainerQueryRegistry from '../src/template-registry.ts';
 
 interface ElementHelperSignature<T extends string> {
   Args: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,9 +296,6 @@ importers:
       '@rollup/plugin-babel':
         specifier: ^6.0.3
         version: 6.0.3(@babel/core@7.22.5)(rollup@3.25.1)
-      '@rollup/plugin-node-resolve':
-        specifier: ^15.1.0
-        version: 15.1.0(rollup@3.25.1)
       '@tsconfig/ember':
         specifier: ^2.0.0
         version: 2.0.0
@@ -3936,24 +3933,6 @@ packages:
       rollup: 3.25.1
     dev: true
 
-  /@rollup/plugin-node-resolve@15.1.0(rollup@3.25.1):
-    resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.78.0||^3.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-builtin-module: 3.2.1
-      is-module: 1.0.0
-      resolve: 1.22.2
-      rollup: 3.25.1
-    dev: true
-
   /@rollup/pluginutils@4.2.1:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
     engines: {node: '>= 8.0.0'}
@@ -4352,10 +4331,6 @@ packages:
 
   /@types/range-parser@1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==}
-    dev: true
-
-  /@types/resolve@1.20.2:
-    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
   /@types/responselike@1.0.0:
@@ -6417,11 +6392,6 @@ packages:
       ieee754: 1.2.1
     dev: true
 
-  /builtin-modules@3.3.0:
-    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
-    engines: {node: '>=6'}
-    dev: true
-
   /builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
@@ -7526,11 +7496,6 @@ packages:
 
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-    dev: true
-
-  /deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
     dev: true
 
   /defaults@1.0.4:
@@ -10679,13 +10644,6 @@ packages:
     resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
     dev: true
 
-  /is-builtin-module@3.2.1:
-    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
-    engines: {node: '>=6'}
-    dependencies:
-      builtin-modules: 3.3.0
-    dev: true
-
   /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -10797,10 +10755,6 @@ packages:
     resolution: {integrity: sha512-zJdQ3QTeLye+iphMeK3wks+vXSRFKh68/Pnlw7aOfApFSEIOhYa8P9vwwa6QrImNNBMJTiL1PpYF0f4BxDuEgA==}
     dependencies:
       '@babel/runtime': 7.22.5
-    dev: true
-
-  /is-module@1.0.0:
-    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
     dev: true
 
   /is-negative-zero@2.0.2:


### PR DESCRIPTION
## Description

In [`@embroider/addon-blueprint@2.0.0`](https://github.com/embroider-build/addon-blueprint/releases/tag/v2.0.0) and [`2.1.0`](https://github.com/embroider-build/addon-blueprint/releases/tag/v2.1.0), end-developers are expected to (1) _not_ use `@rollup/plugin-node-resolve` and (2) add the file extension `.ts` when using relative imports.


## References

- https://github.com/ijlee2/ember-codemod-v1-to-v2/pull/57