### PR TITLE
Dropped Node 16 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 18
   PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_number }}
   PERCY_PARALLEL_TOTAL: 9
 
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2
@@ -116,7 +116,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2
@@ -159,7 +159,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2
@@ -198,7 +198,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out a copy of the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v2

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ For more examples, I encourage you to check out the code for my demo app. It is 
 
 * `ember-auto-import@v2`<sup>1</sup>
 * Ember.js v4.4 or above
-* Node.js v16 or above
+* Node.js v18 or above
 
 <sup>1. `ember-container-query` is a v2 addon. This means, your project must have `ember-auto-import@v2`. If you are momentarily stuck with `ember-auto-import@v1`, you can use [`ember-container-query@v3.2.0`](https://github.com/ijlee2/ember-container-query/tree/3.2.0) to make container queries.</sup>
 

--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -122,7 +122,7 @@
     "webpack": "^5.88.2"
   },
   "engines": {
-    "node": "16.* || >= 18"
+    "node": "18.* || >= 20"
   },
   "ember": {
     "edition": "octane"

--- a/ember-container-query/README.md
+++ b/ember-container-query/README.md
@@ -361,7 +361,7 @@ For more examples, I encourage you to check out the code for my demo app. It is 
 
 * `ember-auto-import@v2`<sup>1</sup>
 * Ember.js v4.4 or above
-* Node.js v16 or above
+* Node.js v18 or above
 
 <sup>1. `ember-container-query` is a v2 addon. This means, your project must have `ember-auto-import@v2`. If you are momentarily stuck with `ember-auto-import@v1`, you can use [`ember-container-query@v3.2.0`](https://github.com/ijlee2/ember-container-query/tree/3.2.0) to make container queries.</sup>
 

--- a/ember-container-query/package.json
+++ b/ember-container-query/package.json
@@ -110,7 +110,7 @@
     "typescript": "^5.2.2"
   },
   "engines": {
-    "node": "16.* || >= 18"
+    "node": "18.* || >= 20"
   },
   "ember": {
     "edition": "octane"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lerna-changelog": "^2.2.0"
   },
   "engines": {
-    "node": "16.* || >= 18"
+    "node": "18.* || >= 20"
   },
   "changelog": {
     "labels": {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -94,7 +94,7 @@
     "webpack": "^5.88.2"
   },
   "engines": {
-    "node": "16.* || >= 18"
+    "node": "18.* || >= 20"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## Background

Node 16 LTS is no longer supported as of September 11, 2023. Node 18 LTS will be supported until April 30, 2025.


## Notes

I reconfigured Netlify so that Node 18 is used for continuous deployment.
