### PR TITLE
Downstreamed changes from @embroider/addon-blueprint@2.11.0

### DIFF
--- a/ember-container-query/babel.config.json
+++ b/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/ember-container-query/package.json
+++ b/ember-container-query/package.json
@@ -66,15 +66,13 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.7",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.8.5",
     "ember-modifier": "^4.1.0",
     "ember-resize-observer-service": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.6",
-    "@babel/plugin-proposal-decorators": "^7.23.6",
-    "@babel/plugin-transform-class-properties": "^7.23.3",
-    "@babel/plugin-transform-class-static-block": "^7.23.4",
     "@babel/plugin-transform-typescript": "^7.23.6",
     "@babel/runtime": "^7.23.6",
     "@embroider/addon-dev": "^4.1.3",

--- a/ember-container-query/tsconfig.json
+++ b/ember-container-query/tsconfig.json
@@ -4,6 +4,7 @@
     "allowImportingTsExtensions": true,
     "allowJs": true,
     "declarationDir": "declarations",
+    "rootDir": "./src",
     "skipLibCheck": true
   },
   "include": [

--- a/ember-container-query/unpublished-development-types/index.d.ts
+++ b/ember-container-query/unpublished-development-types/index.d.ts
@@ -2,6 +2,7 @@
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
 
 import '@glint/environment-ember-loose';
+import '@glint/environment-ember-template-imports';
 
 import type EmberElementHelperRegistry from 'ember-element-helper/template-registry';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,6 +430,9 @@ importers:
       '@embroider/addon-shim':
         specifier: ^1.8.7
         version: 1.8.7
+      decorator-transforms:
+        specifier: ^1.0.1
+        version: 1.0.1(@babel/core@7.23.6)
       ember-element-helper:
         specifier: ^0.8.5
         version: 0.8.5(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(ember-source@5.5.0)
@@ -443,15 +446,6 @@ importers:
       '@babel/core':
         specifier: ^7.23.6
         version: 7.23.6(supports-color@8.1.1)
-      '@babel/plugin-proposal-decorators':
-        specifier: ^7.23.6
-        version: 7.23.6(@babel/core@7.23.6)
-      '@babel/plugin-transform-class-properties':
-        specifier: ^7.23.3
-        version: 7.23.3(@babel/core@7.23.6)
-      '@babel/plugin-transform-class-static-block':
-        specifier: ^7.23.4
-        version: 7.23.4(@babel/core@7.23.6)
       '@babel/plugin-transform-typescript':
         specifier: ^7.23.6
         version: 7.23.6(@babel/core@7.23.6)
@@ -6751,6 +6745,15 @@ packages:
     dependencies:
       mimic-response: 1.0.1
     dev: true
+
+  /decorator-transforms@1.0.1(@babel/core@7.23.6):
+    resolution: {integrity: sha512-ZOaiw4tqiyhtqiMKCNzjS+nGsYPZltToqRAFc5rOUcc4u8d7MTlgelw1qXfL6ieg2l6xZcz6lTZ5M94Ohnk2xA==}
+    dependencies:
+      '@babel/plugin-syntax-decorators': 7.23.3(@babel/core@7.23.6)
+      babel-import-util: 2.0.1
+    transitivePeerDependencies:
+      - '@babel/core'
+    dev: false
 
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}


### PR DESCRIPTION
## Description

By replacing a few Babel plugins with [`decorator-transforms`](https://github.com/ef4/decorator-transforms), we can ship fewer bytes and avoid the need to transpile other class features.

| | Before | After |
|--:|:--:|:--:|
| Package size | 15.7 kB | 14.6 kB |
| Unpacked size | 54.3 kB | 49.7 kB |
| Total files | 40 | 38 |
