### PR TITLE
Reverted the unintended change to ember-modifier support

### DIFF
--- a/ember-container-query/package.json
+++ b/ember-container-query/package.json
@@ -68,7 +68,7 @@
     "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.8.5",
-    "ember-modifier": "^4.1.0",
+    "ember-modifier": "^3.2.7 || ^4.1.0",
     "ember-resize-observer-service": "^1.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,7 +434,7 @@ importers:
         specifier: ^0.8.5
         version: 0.8.5(@glint/environment-ember-loose@1.2.1)(@glint/template@1.2.1)(ember-source@5.5.0)
       ember-modifier:
-        specifier: ^4.1.0
+        specifier: ^3.2.7 || ^4.1.0
         version: 4.1.0(ember-source@5.5.0)
       ember-resize-observer-service:
         specifier: ^1.1.0


### PR DESCRIPTION
## Description

For #216, I had used `pnpm update -rL` to automatically update all packages to the latest. This had unintentionally restricted which versions of `ember-modifier` are supported.
