### PR TITLE
Update CSS selector name in test helper

### DIFF
--- a/docs-app/tests/acceptance/album/visual-regression-test.ts
+++ b/docs-app/tests/acceptance/album/visual-regression-test.ts
@@ -50,16 +50,17 @@ module('Acceptance | album', function (hooks) {
 
   test('@w3 @h1 Visual snapshot', async function (assert) {
     assert
-      .dom('[data-test-table="Tracks"]')
-      .exists('We see the album tracks in a table.');
-
-    assert
-      .dom('[data-test-table="Tracks"] [data-test-row]')
-      .exists({ count: 11 }, 'We see 11 tracks.');
+      .dom('[data-test-list="Tracks"]')
+      .exists('We see the album tracks in a list.')
+      .hasAttribute(
+        'data-css-grid',
+        '4 x 3',
+        'We see 11 tracks in a 4 x 3 grid.',
+      );
 
     assert
       .dom('[data-test-track-lyrics]')
-      .exists("We see the current track's lyrics.");
+      .doesNotExist("We don't see the current track's lyrics.");
 
     await takeSnapshot(assert);
   });

--- a/docs-app/tests/helpers/reset-viewport.ts
+++ b/docs-app/tests/helpers/reset-viewport.ts
@@ -2,7 +2,7 @@
   Do not allow ember-qunit to resize the viewport! Resizing the viewport causes
   issues with tests and Percy snapshots for this addon.
 
-  https://github.com/emberjs/ember-qunit/blob/master/vendor/ember-qunit/test-container-styles.css
+  https://github.com/emberjs/ember-qunit/blob/v8.1.0/addon/src/test-container-styles.css#L33
 */
 export function resetViewport(hooks: NestedHooks): void {
   hooks.beforeEach(function () {
@@ -10,6 +10,6 @@ export function resetViewport(hooks: NestedHooks): void {
       'ember-testing-container',
     )!;
 
-    testingContainer.classList.add('full-screen');
+    testingContainer.classList.add('ember-testing-container-full-screen');
   });
 }


### PR DESCRIPTION
## Background

[`ember-qunit@v5`](https://github.com/emberjs/ember-qunit/blob/v5.1.5/vendor/ember-qunit/test-container-styles.css#L33) had supported the CSS class selector `.full-screen`. In [`6.0.0`](https://github.com/emberjs/ember-qunit/blob/v6.0.0/vendor/ember-qunit/test-container-styles.css#L33), the selector had been renamed to `.ember-testing-container-full-screen`.

Latest version: https://github.com/emberjs/ember-qunit/blob/v8.1.0/addon/src/test-container-styles.css#L33
