### PR TITLE
Changed ember-qunit theme to ember

### DIFF
--- a/docs-app/ember-cli-build.js
+++ b/docs-app/ember-cli-build.js
@@ -11,6 +11,14 @@ function isProduction() {
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     // Add options here
+    '@embroider/macros': {
+      setConfig: {
+        'ember-qunit': {
+          theme: 'ember',
+        },
+      },
+    },
+
     autoImport: {
       watchDependencies: ['ember-container-query'],
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,9 @@ importers:
       '@embroider/broccoli-side-watch':
         specifier: 0.0.2-unstable.ba9fd29
         version: 0.0.2-unstable.ba9fd29
+      '@embroider/macros':
+        specifier: ^1.16.3
+        version: 1.16.3(@glint/template@1.4.0)
       '@embroider/test-setup':
         specifier: ^4.0.0
         version: 4.0.0
@@ -1331,7 +1334,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7(supports-color@8.1.1)
+      '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.7):
@@ -1925,7 +1928,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.24.7(supports-color@8.1.1)
+      '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.7
 
   /@babel/plugin-transform-private-methods@7.24.7(@babel/core@7.24.7):

--- a/test-app/ember-cli-build.js
+++ b/test-app/ember-cli-build.js
@@ -6,6 +6,14 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   const app = new EmberApp(defaults, {
     // Add options here
+    '@embroider/macros': {
+      setConfig: {
+        'ember-qunit': {
+          theme: 'ember',
+        },
+      },
+    },
+
     autoImport: {
       watchDependencies: ['ember-container-query'],
     },

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -44,6 +44,7 @@
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.0",
     "@embroider/broccoli-side-watch": "0.0.2-unstable.ba9fd29",
+    "@embroider/macros": "^1.16.3",
     "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",


### PR DESCRIPTION
## Background

`ember-qunit@8.1.0` provides a new theme that may become the default in `v9`.
