### PR TITLE
Replaced .js with .ts in publicEntrypoints()

### DIFF
--- a/.changeset/five-planets-act.md
+++ b/.changeset/five-planets-act.md
@@ -1,0 +1,5 @@
+---
+"ember-container-query": patch
+---
+
+Replaced .js with .ts in publicEntrypoints()

--- a/packages/ember-container-query/rollup.config.mjs
+++ b/packages/ember-container-query/rollup.config.mjs
@@ -20,7 +20,7 @@ export default {
     // up your addon's public API. Also make sure your package.json#exports
     // is aligned to the config here.
     // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
-    addon.publicEntrypoints(['**/*.js', 'index.js', 'template-registry.js']),
+    addon.publicEntrypoints(['**/*.js', 'index.ts', 'template-registry.ts']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but


### PR DESCRIPTION
## Background

For `addon.publicEntrypoints()`, I had listed `index.js` and `template-registry.js` (to be explicit about configuration) by following the pattern from `**/*.js`.

I realized that we need to instead list the files as is, i.e. with `.ts` in TypeScript projects. The addons worked without an issue by accident, because [`@embroider/addon-dev` has been including `**/*.ts`](https://github.com/embroider-build/embroider/blob/v5.0.0-%40embroider/addon-dev/packages/addon-dev/src/rollup-public-entrypoints.ts#L20).
