### PR TITLE
Remove inject, use service to inject service. Resolves deprecation in ember 6.1+

### DIFF
--- a/.changeset/short-tables-reply.md
+++ b/.changeset/short-tables-reply.md
@@ -1,0 +1,5 @@
+---
+"ember-container-query": patch
+---
+
+Removed `inject as service`

--- a/README.md
+++ b/README.md
@@ -359,10 +359,8 @@ For more examples, I encourage you to check out the code for my demo app. It is 
 
 ## Compatibility
 
-- Ember.js v4.12 or above<sup>1</sup>
+- Ember.js v4.12 or above
 - Node.js v18 or above
-
-<sup>1. `ember-container-query` may work on older versions of Ember (e.g. `4.4`), but issues that arise from these won't be supported.</sup>
 
 
 ## Contributing

--- a/packages/ember-container-query/README.md
+++ b/packages/ember-container-query/README.md
@@ -359,10 +359,8 @@ For more examples, I encourage you to check out the code for my demo app. It is 
 
 ## Compatibility
 
-- Ember.js v4.12 or above<sup>1</sup>
+- Ember.js v4.12 or above
 - Node.js v18 or above
-
-<sup>1. `ember-container-query` may work on older versions of Ember (e.g. `4.4`), but issues that arise from these won't be supported.</sup>
 
 
 ## Contributing

--- a/packages/ember-container-query/src/modifiers/container-query.ts
+++ b/packages/ember-container-query/src/modifiers/container-query.ts
@@ -2,7 +2,7 @@ import { registerDestructor } from '@ember/destroyable';
 import { action } from '@ember/object';
 import type Owner from '@ember/owner';
 import { debounce as _debounce } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type { ArgsFor, NamedArgs, PositionalArgs } from 'ember-modifier';
 import Modifier from 'ember-modifier';
 


### PR DESCRIPTION



Similar to: https://github.com/ember-cli/ember-page-title/pull/293 
Except this is a non-breaking change, since ember-container-query's min-supported ember is already sufficient to use `service`