### PR TITLE
Moved @glimmer/component back to devDependencies

### DIFF
--- a/.changeset/chubby-rice-try.md
+++ b/.changeset/chubby-rice-try.md
@@ -1,0 +1,5 @@
+---
+"ember-container-query": patch
+---
+
+Moved @glimmer/component back to devDependencies

--- a/.changeset/curvy-cycles-flow.md
+++ b/.changeset/curvy-cycles-flow.md
@@ -1,0 +1,6 @@
+---
+"docs-app": patch
+"test-app": patch
+---
+
+Pinned ember-auto-import to 2.10.0

--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -78,7 +78,7 @@
     "d3-shape": "^3.2.0",
     "ember-a11y-refocus": "^5.1.0",
     "ember-a11y-testing": "^7.1.2",
-    "ember-auto-import": "^2.10.1",
+    "ember-auto-import": "^2.10.0",
     "ember-cli": "~6.7.0",
     "ember-cli-app-version": "^7.0.0",
     "ember-cli-babel": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,10 @@
   "engines": {
     "node": "20.* || >= 22",
     "pnpm": ">= 10"
+  },
+  "pnpm": {
+    "overrides": {
+      "ember-auto-import": "2.10.0"
+    }
   }
 }

--- a/packages/ember-container-query/package.json
+++ b/packages/ember-container-query/package.json
@@ -64,7 +64,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.10.0",
-    "@glimmer/component": "^2.0.0",
     "decorator-transforms": "^2.3.0",
     "ember-element-helper": "^0.8.8",
     "ember-modifier": "^4.2.2",
@@ -75,6 +74,7 @@
     "@babel/plugin-transform-typescript": "^7.28.0",
     "@babel/runtime": "^7.28.4",
     "@embroider/addon-dev": "^8.1.0",
+    "@glimmer/component": "^2.0.0",
     "@glimmer/tracking": "^1.1.2",
     "@glint/core": "^1.5.2",
     "@glint/environment-ember-loose": "^1.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+overrides:
+  ember-auto-import: 2.10.0
+
 importers:
 
   .:
@@ -129,8 +132,8 @@ importers:
         specifier: ^7.1.2
         version: 7.1.2(@ember/test-helpers@5.3.0(@babel/core@7.28.4)(@glint/template@1.5.2))(@glint/template@1.5.2)(qunit@2.24.1)(webpack@5.101.3)
       ember-auto-import:
-        specifier: ^2.10.1
-        version: 2.10.1(@glint/template@1.5.2)(webpack@5.101.3)
+        specifier: 2.10.0
+        version: 2.10.0(@glint/template@1.5.2)(webpack@5.101.3)
       ember-cli:
         specifier: ~6.7.0
         version: 6.7.0(@types/node@24.5.2)(handlebars@4.7.8)(underscore@1.13.7)
@@ -236,9 +239,6 @@ importers:
       '@embroider/addon-shim':
         specifier: ^1.10.0
         version: 1.10.0
-      '@glimmer/component':
-        specifier: ^2.0.0
-        version: 2.0.0
       decorator-transforms:
         specifier: ^2.3.0
         version: 2.3.0(@babel/core@7.28.4)
@@ -264,6 +264,9 @@ importers:
       '@embroider/addon-dev':
         specifier: ^8.1.0
         version: 8.1.0(@glint/template@1.5.2)(rollup@4.52.2)
+      '@glimmer/component':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2
@@ -382,8 +385,8 @@ importers:
         specifier: ^7.1.2
         version: 7.1.2(@ember/test-helpers@5.3.0(@babel/core@7.28.4)(@glint/template@1.5.2))(@glint/template@1.5.2)(qunit@2.24.1)(webpack@5.101.3)
       ember-auto-import:
-        specifier: ^2.10.1
-        version: 2.10.1(@glint/template@1.5.2)(webpack@5.101.3)
+        specifier: 2.10.0
+        version: 2.10.0(@glint/template@1.5.2)(webpack@5.101.3)
       ember-cli:
         specifier: ~6.7.0
         version: 6.7.0(@types/node@24.5.2)(handlebars@4.7.8)(underscore@1.13.7)
@@ -3632,8 +3635,8 @@ packages:
       qunit:
         optional: true
 
-  ember-auto-import@2.10.1:
-    resolution: {integrity: sha512-5K4lYSEBch3DKQn1VElFHDHcHTvhTJnB6aebf24VyIobLL+OMWORcCK1fiwyfPiVABztyuLXH2GiXDweNUtntA==}
+  ember-auto-import@2.10.0:
+    resolution: {integrity: sha512-bcBFDYVTFHyqyq8BNvsj6UO3pE6Uqou/cNmee0WaqBgZ+1nQqFz0UE26usrtnFAT+YaFZSkqF2H36QW84k0/cg==}
     engines: {node: 12.* || 14.* || >= 16}
 
   ember-cli-app-version@7.0.0:
@@ -9445,7 +9448,7 @@ snapshots:
   '@percy/ember@5.0.0(@babel/core@7.28.4)(@glint/template@1.5.2)(webpack@5.101.3)':
     dependencies:
       '@percy/sdk-utils': 1.31.2
-      ember-auto-import: 2.10.1(@glint/template@1.5.2)(webpack@5.101.3)
+      ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.3)
       ember-cli-babel: 8.2.0(@babel/core@7.28.4)
     transitivePeerDependencies:
       - '@babel/core'
@@ -11553,7 +11556,7 @@ snapshots:
       '@scalvert/ember-setup-middleware-reporter': 0.1.1
       axe-core: 4.10.3
       broccoli-persistent-filter: 3.1.3
-      ember-auto-import: 2.10.1(@glint/template@1.5.2)(webpack@5.101.3)
+      ember-auto-import: 2.10.0(@glint/template@1.5.2)(webpack@5.101.3)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
       ember-cli-typescript: 4.2.1
@@ -11567,7 +11570,7 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-auto-import@2.10.1(@glint/template@1.5.2)(webpack@5.101.3):
+  ember-auto-import@2.10.0(@glint/template@1.5.2)(webpack@5.101.3):
     dependencies:
       '@babel/core': 7.28.4(supports-color@8.1.1)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.28.4)

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -61,7 +61,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.2.1",
     "ember-a11y-testing": "^7.1.2",
-    "ember-auto-import": "^2.10.1",
+    "ember-auto-import": "^2.10.0",
     "ember-cli": "~6.7.0",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-clean-css": "^3.0.0",


### PR DESCRIPTION
## Background

Partially reverts #265.

We can list `@glimmer/component` in `devDependencies` for v2 addons. A bug in `ember-auto-import@2.10.1` is to be fixed.

Related: https://github.com/embroider-build/ember-auto-import/issues/665
