### PR TITLE
Began testing ember-lts-6.12, ember-beta, and ember-canary scenarios

### DIFF
--- a/.changeset/clever-laws-argue.md
+++ b/.changeset/clever-laws-argue.md
@@ -1,0 +1,6 @@
+---
+"ember-container-query": patch
+"test-app": patch
+---
+
+Began testing ember-lts-6.12, ember-beta, and ember-canary scenarios

--- a/test-app/.try.mjs
+++ b/test-app/.try.mjs
@@ -18,10 +18,10 @@ export default {
       },
     },
     {
-      name: 'ember-lts-6.8',
+      name: 'ember-lts-6.12',
       npm: {
         devDependencies: {
-          'ember-source': '~6.8.0',
+          'ember-source': '~6.12.0',
         },
       },
     },

--- a/test-app/.try.mjs
+++ b/test-app/.try.mjs
@@ -33,21 +33,21 @@ export default {
         },
       },
     },
-    // {
-    //   name: 'ember-beta',
-    //   npm: {
-    //     devDependencies: {
-    //       'ember-source': 'npm:ember-source@beta',
-    //     },
-    //   },
-    // },
-    // {
-    //   name: 'ember-canary',
-    //   npm: {
-    //     devDependencies: {
-    //       'ember-source': 'npm:ember-source@alpha',
-    //     },
-    //   },
-    // },
+    {
+      name: 'ember-beta',
+      npm: {
+        devDependencies: {
+          'ember-source': 'npm:ember-source@beta',
+        },
+      },
+    },
+    {
+      name: 'ember-canary',
+      npm: {
+        devDependencies: {
+          'ember-source': 'npm:ember-source@alpha',
+        },
+      },
+    },
   ],
 };


### PR DESCRIPTION
## Why?

Follows up on https://github.com/ijlee2/ember-container-query/pull/285 and https://github.com/ijlee2/ember-container-query/pull/294.


## What changed?

- Replaced `ember-lts-6.8` with `ember-lts-6.12`.
- Enabled `ember-beta` and `ember-canary` to show compatibility with `ember-source@7.0.0`.
